### PR TITLE
Cleanup: Add getRecipientAddress to RelayerAbstract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/packages/aptos/src/context.ts
+++ b/packages/aptos/src/context.ts
@@ -15,7 +15,6 @@ import {
   hexToUint8Array,
   parseTokenTransferPayload,
   TokenBridgeAbstract,
-  MAINNET_CHAINS,
 } from '@wormhole-foundation/connect-sdk';
 import { AptosContracts } from './contracts';
 import {
@@ -61,22 +60,19 @@ export class AptosContext extends TokenBridgeAbstract<Types.EntryFunctionPayload
     const destContext = this.wormhole.getContext(recipientChain);
     const recipientChainId = this.wormhole.toChainId(recipientChain);
 
-    let recipientAccount = recipientAddress;
-    // get token account for solana
-    if (recipientChainId === MAINNET_CHAINS.solana) {
-      let tokenId = token;
-      if (token === NATIVE) {
-        tokenId = {
-          address: APTOS_COIN,
-          chain: 'aptos',
-        };
-      }
-      recipientAccount = await this.wormhole.getSolanaRecipientAddress(
-        recipientChain,
-        tokenId as TokenId,
-        recipientAddress,
-      );
-    }
+    const tokenId: TokenId =
+      token === NATIVE
+        ? {
+            address: APTOS_COIN,
+            chain: 'aptos',
+          }
+        : token;
+
+    const recipientAccount = await destContext.getRecipientAddress(
+      tokenId,
+      recipientAddress,
+    );
+
     const formattedRecipientAccount = arrayify(
       destContext.formatAddress(recipientAccount),
     );

--- a/packages/evm/src/context.ts
+++ b/packages/evm/src/context.ts
@@ -27,8 +27,6 @@ import {
   parseVaa,
   RelayerAbstract,
   createNonce,
-  MAINNET_CHAINS,
-  Network,
 } from '@wormhole-foundation/connect-sdk';
 import { EvmContracts } from './contracts';
 
@@ -190,22 +188,18 @@ export class EvmContext extends RelayerAbstract<ethers.ContractReceipt> {
     const amountBN = ethers.BigNumber.from(amount);
     const bridge = this.contracts.mustGetBridge(sendingChain);
 
-    let recipientAccount = recipientAddress;
-    // get token account for solana
-    if (recipientChainId === MAINNET_CHAINS.solana) {
-      let tokenId = token;
-      if (token === NATIVE) {
-        tokenId = {
-          address: await bridge.WETH(),
-          chain: sendingChainName,
-        };
-      }
-      recipientAccount = await this.wormhole.getSolanaRecipientAddress(
-        recipientChain,
-        tokenId as TokenId,
-        recipientAddress,
-      );
-    }
+    const tokenID: TokenId =
+      token === NATIVE
+        ? {
+            address: await bridge.WETH(),
+            chain: sendingChainName,
+          }
+        : token;
+
+    const recipientAccount = await destContext.getRecipientAddress(
+      tokenID,
+      recipientAddress,
+    );
 
     if (token === NATIVE) {
       // sending native ETH

--- a/packages/sdk-core/src/abstracts/tokenBridge.ts
+++ b/packages/sdk-core/src/abstracts/tokenBridge.ts
@@ -89,6 +89,21 @@ export abstract class TokenBridgeAbstract<TransactionResult> {
   abstract parseAddress(address: any): string;
 
   /**
+   * Gets the recipient address on the recieving chain.
+   *  Note: this is a NoOp for chains other than Solana with its ATA
+   *
+   * @param tokenId The token identifier (native chain/address)
+   * @param recipientAddress The address of the receiver
+   * @returns The relayer fee
+   */
+  async getRecipientAddress(
+    tokenId: TokenId,
+    recipientAddress: string,
+  ): Promise<string> {
+    return recipientAddress;
+  }
+
+  /**
    * Format a token address to 32-bytes universal address, which can be utilized by the Wormhole contracts
    *
    * How is this different from {@link Wormhole#formatAddress | formatAddress}? Converting some assets to a universal representation might require querying a registry first

--- a/packages/sdk-core/src/wormhole.ts
+++ b/packages/sdk-core/src/wormhole.ts
@@ -49,7 +49,7 @@ import { SeiAbstract } from './abstracts/contexts/sei';
  *   'ethereum', // sending chain
  *   '0x789...', // sender address
  *   'moonbeam', // destination chain
- *   '0x789..., // recipient address on destination chain
+ *   '0x789...', // recipient address on destination chain
  * )
  */
 export class Wormhole extends MultiProvider<Domain> {
@@ -159,31 +159,9 @@ export class Wormhole extends MultiProvider<Domain> {
     return context;
   }
 
-  async getSolanaRecipientAddress(
-    recipientChain: ChainName | ChainId,
-    tokenId: TokenId,
-    recipientAddress: string,
-  ) {
-    const recipientChainId = this.toChainId(recipientChain);
-    if (recipientChainId === MAINNET_CHAINS.solana) {
-      let solanaContext: SolanaAbstract;
-      try {
-        solanaContext = this.getContext(MAINNET_CHAINS.solana) as any;
-      } catch (_) {
-        throw new Error(
-          'You attempted to send a transfer to Solana, but the Solana context is not registered. You must import SolanaContext from @wormhole-foundation/connect-sdk-solana and pass it in to the Wormhole class constructor',
-        );
-      }
-      const account = await solanaContext.getAssociatedTokenAddress(
-        tokenId as TokenId,
-        recipientAddress,
-      );
-      return account.toString();
-    }
-  }
-
   /**
-   * Fetches the address for a token representation on any chain (These are the Wormhole token addresses, not necessarily the cannonical version of that token)
+   * Fetches the address for a token representation on any chain
+   *  These are the Wormhole token addresses, not necessarily the cannonical version of that token
    *
    * @param tokenId The Token ID (chain/address)
    * @param chain The chain name or id
@@ -198,7 +176,8 @@ export class Wormhole extends MultiProvider<Domain> {
   }
 
   /**
-   * Fetches the address for a token representation on any chain (These are the Wormhole token addresses, not necessarily the cannonical version of that token)
+   * Fetches the address for a token representation on any chain
+   *  These are the Wormhole token addresses, not necessarily the cannonical version of that token
    *
    * @param tokenId The Token ID (chain/address)
    * @param chain The chain name or id
@@ -296,7 +275,9 @@ export class Wormhole extends MultiProvider<Domain> {
         seiContext = this.getContext(MAINNET_CHAINS.solana) as any;
       } catch (_) {
         throw new Error(
-          'You attempted to send a transfer to Sei, but the Sei context is not registered. You must import SeiContext from @wormhole-foundation/connect-sdk-sei and pass it in to the Wormhole class constructor',
+          'You attempted to send a transfer to Sei, but the Sei context is not registered. ' +
+            'You must import SeiContext from @wormhole-foundation/connect-sdk-sei and pass it ' +
+            'in to the Wormhole class constructor',
         );
       }
       const { payload: seiPayload, receiver } =
@@ -431,7 +412,8 @@ export class Wormhole extends MultiProvider<Domain> {
   }
 
   /**
-   * Gets a VAA from the API or Guardian RPC, finality must be met before the VAA will be available. See {@link ChainConfig.finalityThreshold | finalityThreshold} on {@link MAINNET_CONFIG | the config}
+   * Gets a VAA from the API or Guardian RPC, finality must be met before the VAA will be available.
+   *  See {@link ChainConfig.finalityThreshold | finalityThreshold} on {@link MAINNET_CONFIG | the config}
    *
    * @param msg The MessageIdentifier used to fetch the VAA
    * @returns The ParsedVAA if available

--- a/packages/sei/src/context.ts
+++ b/packages/sei/src/context.ts
@@ -41,7 +41,6 @@ import {
   parseTokenTransferPayload,
   parseVaa,
   NATIVE,
-  Network,
   SeiAbstract,
 } from '@wormhole-foundation/connect-sdk';
 import { SeiContracts } from './contracts';
@@ -173,15 +172,10 @@ export class SeiContext
     const destContext = this.wormhole.getContext(recipientChain);
     const targetChain = this.wormhole.toChainId(recipientChain);
 
-    let recipientAccount = recipientAddress;
-    // get token account for solana
-    if (targetChain === MAINNET_CHAINS.solana) {
-      recipientAccount = await this.wormhole.getSolanaRecipientAddress(
-        recipientChain,
-        token as TokenId,
-        recipientAddress,
-      );
-    }
+    const recipientAccount = await destContext.getRecipientAddress(
+      token,
+      recipientAddress,
+    );
 
     const targetAddress = Buffer.from(
       destContext.formatAddress(recipientAccount),

--- a/packages/solana/src/context.ts
+++ b/packages/solana/src/context.ts
@@ -182,6 +182,17 @@ export class SolanaContext
     );
   }
 
+  async getRecipientAddress(
+    tokenId: TokenId,
+    recipientAddress: string,
+  ): Promise<string> {
+    const account = await this.getAssociatedTokenAddress(
+      tokenId,
+      recipientAddress,
+    );
+    return account.toString();
+  }
+
   /**
    * Gets the Associate Token Account
    *

--- a/packages/sui/src/context.ts
+++ b/packages/sui/src/context.ts
@@ -22,8 +22,6 @@ import {
   parseTokenTransferPayload,
   Wormhole,
   RelayerAbstract,
-  MAINNET_CHAINS,
-  Network,
 } from '@wormhole-foundation/connect-sdk';
 
 import { SuiContracts } from './contracts';
@@ -87,22 +85,19 @@ export class SuiContext extends RelayerAbstract<TransactionBlock> {
     const relayerFeeBigInt = relayerFee ? BigInt(relayerFee) : undefined;
     const amountBigInt = BigNumber.from(amount).toBigInt();
 
-    let recipientAccount = recipientAddress;
-    // get token account for solana
-    if (recipientChainId === MAINNET_CHAINS.solana) {
-      let tokenId = token;
-      if (token === NATIVE) {
-        tokenId = {
-          address: SUI_TYPE_ARG,
-          chain: 'sui',
-        };
-      }
-      recipientAccount = await this.wormhole.getSolanaRecipientAddress(
-        recipientChain,
-        tokenId as TokenId,
-        recipientAddress,
-      );
-    }
+    const tokenId: TokenId =
+      token === NATIVE
+        ? {
+            address: SUI_TYPE_ARG,
+            chain: 'sui',
+          }
+        : token;
+
+    const recipientAccount = await destContext.getRecipientAddress(
+      tokenId,
+      recipientAddress,
+    );
+
     const formattedRecipientAccount = arrayify(
       destContext.formatAddress(recipientAccount),
     );
@@ -408,22 +403,19 @@ export class SuiContext extends RelayerAbstract<TransactionBlock> {
     const amountBigInt = BigNumber.from(amount).toBigInt();
     const toNativeTokenBigInt = BigNumber.from(toNativeToken).toBigInt();
 
-    let recipientAccount = recipientAddress;
-    // get token account for solana
-    if (recipientChainId === MAINNET_CHAINS.solana) {
-      let tokenId = token;
-      if (token === NATIVE) {
-        tokenId = {
-          address: SUI_TYPE_ARG,
-          chain: 'sui',
-        };
-      }
-      recipientAccount = await this.wormhole.getSolanaRecipientAddress(
-        recipientChain,
-        tokenId as TokenId,
-        recipientAddress,
-      );
-    }
+    const tokenId: TokenId =
+      token === NATIVE
+        ? {
+            address: SUI_TYPE_ARG,
+            chain: 'sui',
+          }
+        : token;
+
+    const recipientAccount = await destContext.getRecipientAddress(
+      tokenId,
+      recipientAddress,
+    );
+
     const formattedRecipientAccount = `0x${Buffer.from(
       arrayify(destContext.formatAddress(recipientAccount)),
     ).toString('hex')}`;


### PR DESCRIPTION
Every context had some check to see if the transfer was meant for Solana since it requires a different receiver address than the main account.

This pr adds a `getRecipientAddress` to the RelayerAbstract class with the default implementation of returning the same address. Currently only `SolanaContext` overrides this method to provide the ATA address