### PR TITLE
Sei: refactor check for sei receiver, add error

### DIFF
--- a/packages/sdk-core/src/errors.ts
+++ b/packages/sdk-core/src/errors.ts
@@ -1,3 +1,13 @@
-export function NoProviderError(chain: string | number) {
-  return `Missing provider for domain: ${chain}.\nHint: Have you called \`context.registerProvider(${chain}, provider)\` yet?`;
+export function NoProviderError(chain: string | number): Error {
+  return new Error(
+    `Missing provider for domain: ${chain}.\nHint: Have you called \`context.registerProvider(${chain}, provider)\` yet?`,
+  );
+}
+
+export function NoContextError(chain: string | number): Error {
+  // TODO: lookup chain name/id for better error messages
+  return new Error(
+    `You attempted to send a transfer to ${chain}, but the ${chain} context is not registered. ` +
+      `You must import ${chain} from @wormhole-foundation/connect-sdk-sei and pass it in to the Wormhole class constructor`,
+  );
 }


### PR DESCRIPTION
There is a bug in the current `sei` check, trying to get context for Solana.

This should fix that but also adds a new Error type to help standardize the errors we throw.

---

I think we should consider renaming `sei` to `cosmwasm` or something to prepare for Gateway transactions, which should have approximately the same behavior but a different payload