### PR TITLE
Make platforms modules

### DIFF
--- a/connect/__tests__/index.test.ts
+++ b/connect/__tests__/index.test.ts
@@ -7,61 +7,67 @@ import {
 } from '@wormhole-foundation/sdk-definitions';
 import { PlatformName, platforms } from '@wormhole-foundation/sdk-base';
 import { Wormhole } from '../src';
-
-const allPlatformCtrs = platforms.map((p) => {
-  return testing.mocks.mockPlatformFactory(p);
-});
-
-describe('Wormhole Tests', () => {
-  let wh: Wormhole;
-  beforeEach(() => {
-    wh = new Wormhole('Devnet', allPlatformCtrs);
-  });
-
-  let p: Platform<PlatformName>;
-  test('returns Platform', async () => {
-    p = wh.getPlatform('Ethereum');
-    expect(p).toBeTruthy();
-  });
-
-  let c: ChainContext<PlatformName>;
-  test('returns chain', async () => {
-    c = wh.getChain('Ethereum');
-    expect(c).toBeTruthy();
+describe('Ben restore please', () => {
+  test('lol', async () => {
+    expect(true).toBeTruthy();
   });
 });
 
-describe('Platform Tests', () => {
-  let p: Platform<PlatformName>;
-  beforeEach(() => {
-    const wh = new Wormhole('Devnet', allPlatformCtrs);
-    p = wh.getPlatform('Ethereum');
-  });
-
-  let rpc: RpcConnection<PlatformName>;
-  test('Gets RPC', () => {
-    rpc = p.getRpc('Ethereum');
-    expect(rpc).toBeTruthy();
-  });
-
-  let tb: TokenBridge<PlatformName>;
-  test('Gets Token Bridge', async () => {
-    tb = await p.getTokenBridge(rpc);
-    expect(tb).toBeTruthy();
-  });
-});
-
-describe('Chain Tests', () => {
-  let c: ChainContext<PlatformName>;
-  beforeEach(() => {
-    const wh = new Wormhole('Devnet', allPlatformCtrs);
-    const p = wh.getPlatform('Ethereum');
-    c = wh.getChain('Ethereum');
-  });
-
-  let rpc: RpcConnection<PlatformName>;
-  test('Gets RPC', () => {
-    rpc = c.getRpc();
-    expect(rpc).toBeTruthy();
-  });
-});
+// const allPlatformCtrs = platforms.map((p) => {
+//   return testing.mocks.mockPlatformFactory(p);
+// });
+//
+// describe('Wormhole Tests', () => {
+//   let wh: Wormhole;
+//   beforeEach(() => {
+//     wh = new Wormhole('Devnet', allPlatformCtrs);
+//   });
+//
+//   let p: Platform<PlatformName>;
+//   test('returns Platform', async () => {
+//     p = wh.getPlatform('Ethereum');
+//     expect(p).toBeTruthy();
+//   });
+//
+//   let c: ChainContext<PlatformName>;
+//   test('returns chain', async () => {
+//     c = wh.getChain('Ethereum');
+//     expect(c).toBeTruthy();
+//   });
+// });
+//
+// describe('Platform Tests', () => {
+//   let p: Platform<PlatformName>;
+//   beforeEach(() => {
+//     const wh = new Wormhole('Devnet', allPlatformCtrs);
+//     p = wh.getPlatform('Ethereum');
+//   });
+//
+//   let rpc: RpcConnection<PlatformName>;
+//   test('Gets RPC', () => {
+//     rpc = p.getRpc('Ethereum');
+//     expect(rpc).toBeTruthy();
+//   });
+//
+//   let tb: TokenBridge<PlatformName>;
+//   test('Gets Token Bridge', async () => {
+//     tb = await p.getTokenBridge(rpc);
+//     expect(tb).toBeTruthy();
+//   });
+// });
+//
+// describe('Chain Tests', () => {
+//   let c: ChainContext<PlatformName>;
+//   beforeEach(() => {
+//     const wh = new Wormhole('Devnet', allPlatformCtrs);
+//     const p = wh.getPlatform('Ethereum');
+//     c = wh.getChain('Ethereum');
+//   });
+//
+//   let rpc: RpcConnection<PlatformName>;
+//   test('Gets RPC', () => {
+//     rpc = c.getRpc();
+//     expect(rpc).toBeTruthy();
+//   });
+// });
+//

--- a/connect/__tests__/index.test.ts
+++ b/connect/__tests__/index.test.ts
@@ -5,69 +5,68 @@ import {
   ChainContext,
   testing,
 } from '@wormhole-foundation/sdk-definitions';
-import { PlatformName, platforms } from '@wormhole-foundation/sdk-base';
-import { Wormhole } from '../src';
-describe('Ben restore please', () => {
-  test('lol', async () => {
-    expect(true).toBeTruthy();
+import {
+  Network,
+  PlatformName,
+  platforms,
+} from '@wormhole-foundation/sdk-base';
+import { Wormhole, chainConfigs } from '../src';
+
+const network: Network = 'Devnet';
+const allPlatformCtrs = platforms.map((p) => {
+  return testing.mocks.mockPlatformFactory(p, chainConfigs(network));
+});
+
+describe('Wormhole Tests', () => {
+  let wh: Wormhole;
+  beforeEach(() => {
+    wh = new Wormhole(network, allPlatformCtrs);
+  });
+
+  let p: Platform<PlatformName>;
+  test('returns Platform', async () => {
+    p = wh.getPlatform('Ethereum');
+    expect(p).toBeTruthy();
+  });
+
+  let c: ChainContext<PlatformName>;
+  test('returns chain', async () => {
+    c = wh.getChain('Ethereum');
+    expect(c).toBeTruthy();
   });
 });
 
-// const allPlatformCtrs = platforms.map((p) => {
-//   return testing.mocks.mockPlatformFactory(p);
-// });
-//
-// describe('Wormhole Tests', () => {
-//   let wh: Wormhole;
-//   beforeEach(() => {
-//     wh = new Wormhole('Devnet', allPlatformCtrs);
-//   });
-//
-//   let p: Platform<PlatformName>;
-//   test('returns Platform', async () => {
-//     p = wh.getPlatform('Ethereum');
-//     expect(p).toBeTruthy();
-//   });
-//
-//   let c: ChainContext<PlatformName>;
-//   test('returns chain', async () => {
-//     c = wh.getChain('Ethereum');
-//     expect(c).toBeTruthy();
-//   });
-// });
-//
-// describe('Platform Tests', () => {
-//   let p: Platform<PlatformName>;
-//   beforeEach(() => {
-//     const wh = new Wormhole('Devnet', allPlatformCtrs);
-//     p = wh.getPlatform('Ethereum');
-//   });
-//
-//   let rpc: RpcConnection<PlatformName>;
-//   test('Gets RPC', () => {
-//     rpc = p.getRpc('Ethereum');
-//     expect(rpc).toBeTruthy();
-//   });
-//
-//   let tb: TokenBridge<PlatformName>;
-//   test('Gets Token Bridge', async () => {
-//     tb = await p.getTokenBridge(rpc);
-//     expect(tb).toBeTruthy();
-//   });
-// });
-//
-// describe('Chain Tests', () => {
-//   let c: ChainContext<PlatformName>;
-//   beforeEach(() => {
-//     const wh = new Wormhole('Devnet', allPlatformCtrs);
-//     const p = wh.getPlatform('Ethereum');
-//     c = wh.getChain('Ethereum');
-//   });
-//
-//   let rpc: RpcConnection<PlatformName>;
-//   test('Gets RPC', () => {
-//     rpc = c.getRpc();
-//     expect(rpc).toBeTruthy();
-//   });
-// });
-//
+describe('Platform Tests', () => {
+  let p: Platform<PlatformName>;
+  beforeEach(() => {
+    const wh = new Wormhole(network, allPlatformCtrs);
+    p = wh.getPlatform('Ethereum');
+  });
+
+  let rpc: RpcConnection<PlatformName>;
+  test('Gets RPC', () => {
+    rpc = p.getRpc('Ethereum');
+    expect(rpc).toBeTruthy();
+  });
+
+  let tb: TokenBridge<PlatformName>;
+  test('Gets Token Bridge', async () => {
+    tb = await p.getTokenBridge(rpc);
+    expect(tb).toBeTruthy();
+  });
+});
+
+describe('Chain Tests', () => {
+  let c: ChainContext<PlatformName>;
+  beforeEach(() => {
+    const wh = new Wormhole(network, allPlatformCtrs);
+    const p = wh.getPlatform('Ethereum');
+    c = wh.getChain('Ethereum');
+  });
+
+  let rpc: RpcConnection<PlatformName>;
+  test('Gets RPC', () => {
+    rpc = c.getRpc();
+    expect(rpc).toBeTruthy();
+  });
+});

--- a/connect/src/constants.ts
+++ b/connect/src/constants.ts
@@ -10,6 +10,7 @@ import {
   RoArray,
   constMap,
   circleAPI,
+  PlatformName,
 } from '@wormhole-foundation/sdk-base';
 import { WormholeConfig } from './types';
 import {
@@ -52,6 +53,17 @@ const chainConfigMapping = [
 ] as const satisfies RoArray<readonly [Network, ChainsConfig]>;
 
 export const chainConfigs = constMap(chainConfigMapping);
+
+export function networkPlatformConfigs(
+  network: Network,
+  platform: PlatformName,
+): ChainsConfig {
+  return Object.fromEntries(
+    Object.entries(chainConfigs(network)).filter(([_, v]) => {
+      return v.platform == platform;
+    }),
+  );
+}
 
 const sharedConfig: WormholeConfig = {
   network: 'Testnet',

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -18,7 +18,6 @@ import {
   Platform,
   ChainContext,
   toNative,
-  PlatformCtr,
   Contracts,
   TxHash,
   WormholeMessageId,
@@ -40,22 +39,22 @@ export class Wormhole {
 
   constructor(
     network: Network,
-    platforms: PlatformCtr<PlatformName>[],
+    platforms: Platform<PlatformName>[],
     conf?: WormholeConfig,
   ) {
     this.conf = conf ?? CONFIG[network];
 
     this._platforms = new Map();
     for (const p of platforms) {
-      const platformName = p._platform;
+      const platformName = p.platform;
 
       const filteredChains = Object.fromEntries(
         Object.entries(this.conf.chains).filter(([_, v]) => {
           return v.platform == platformName;
         }),
       );
-
-      this._platforms.set(platformName, new p(filteredChains));
+      p.init(filteredChains);
+      this._platforms.set(platformName, p);
     }
   }
 

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -53,7 +53,7 @@ export class Wormhole {
           return v.platform == platformName;
         }),
       );
-      p.init(filteredChains);
+      p.setConfig(filteredChains);
       this._platforms.set(platformName, p);
     }
   }

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -27,7 +27,7 @@ import axios, { AxiosResponse } from 'axios';
 
 import { WormholeConfig } from './types';
 
-import { CONFIG } from './constants';
+import { CONFIG, networkPlatformConfigs } from './constants';
 import { TokenTransfer } from './protocols/tokenTransfer';
 import { CCTPTransfer } from './protocols/cctpTransfer';
 import { TransactionStatus } from './api';
@@ -47,14 +47,8 @@ export class Wormhole {
     this._platforms = new Map();
     for (const p of platforms) {
       const platformName = p.platform;
-
-      const filteredChains = Object.fromEntries(
-        Object.entries(this.conf.chains).filter(([_, v]) => {
-          return v.platform == platformName;
-        }),
-      );
-      p.setConfig(filteredChains);
-      this._platforms.set(platformName, p);
+      const filteredChains = networkPlatformConfigs(network, platformName);
+      this._platforms.set(platformName, p.setConfig(filteredChains));
     }
   }
 
@@ -86,7 +80,9 @@ export class Wormhole {
 
     if (
       !isCircleChain(from.chain) ||
-      !isCircleSupported(this.network, from.chain)
+      !isCircleChain(to.chain) ||
+      !isCircleSupported(this.network, from.chain) ||
+      !isCircleSupported(this.network, to.chain)
     )
       throw new Error(
         `Network and chain not supported: ${this.network} ${from.chain} `,
@@ -136,6 +132,18 @@ export class Wormhole {
 
     if (nativeGas && !automatic)
       throw new Error('Gas Dropoff is only supported for automatic transfers');
+
+    const fromChain = this.getChain(from.chain);
+    const toChain = this.getChain(to.chain);
+
+    if (!fromChain.supportsTokenBridge())
+      throw new Error(`Token Bridge not supported on ${from.chain}`);
+
+    if (!toChain.supportsTokenBridge())
+      throw new Error(`Token Bridge not supported on ${to.chain}`);
+
+    if (automatic && !fromChain.supportsAutomaticTokenBridge())
+      throw new Error(`Automatic Token Bridge not supported on ${from.chain}`);
 
     // Bit of (temporary) hackery until solana contracts support being
     // sent a VAA with the primary address

--- a/core/definitions/src/platform.ts
+++ b/core/definitions/src/platform.ts
@@ -9,14 +9,13 @@ import { TokenBridge, AutomaticTokenBridge } from "./protocols/tokenBridge";
 import { CircleBridge, AutomaticCircleBridge } from "./protocols/cctp";
 import { WormholeCore } from "./protocols/core";
 import { NativeAddress } from "./address";
-import { Contracts } from "./contracts";
 
 // Force passing RPC connection so we don't create a new one with every fn call
 export interface Platform<P extends PlatformName> {
   readonly platform: P;
   readonly conf: ChainsConfig;
 
-  init(_conf: ChainsConfig): Platform<P>;
+  setConfig(_conf: ChainsConfig): Platform<P>;
 
   getChain(chain: ChainName): ChainContext<P>;
 

--- a/core/definitions/src/platform.ts
+++ b/core/definitions/src/platform.ts
@@ -4,10 +4,6 @@ import { RpcConnection } from "./rpc";
 import { ChainsConfig, TokenId, TxHash } from "./types";
 import { WormholeMessageId } from "./attestation";
 import { SignedTx } from "./types";
-// protocols
-import { TokenBridge, AutomaticTokenBridge } from "./protocols/tokenBridge";
-import { CircleBridge, AutomaticCircleBridge } from "./protocols/cctp";
-import { WormholeCore } from "./protocols/core";
 import { NativeAddress } from "./address";
 
 // Force passing RPC connection so we don't create a new one with every fn call
@@ -15,8 +11,10 @@ export interface Platform<P extends PlatformName> {
   readonly platform: P;
   readonly conf: ChainsConfig;
 
+  // update the config for this platform
   setConfig(_conf: ChainsConfig): Platform<P>;
 
+  // Create a new Chain context object
   getChain(chain: ChainName): ChainContext<P>;
 
   // Utils for platform specific queries
@@ -45,15 +43,4 @@ export interface Platform<P extends PlatformName> {
     txid: TxHash
   ): Promise<WormholeMessageId[]>;
   parseAddress(chain: ChainName, address: string): NativeAddress<P>;
-
-  // protocol clients
-  getWormholeCore(rpc: RpcConnection<P>): Promise<WormholeCore<P>>;
-  getTokenBridge(rpc: RpcConnection<P>): Promise<TokenBridge<P>>;
-  getAutomaticTokenBridge(
-    rpc: RpcConnection<P>
-  ): Promise<AutomaticTokenBridge<P>>;
-  getAutomaticCircleBridge(
-    rpc: RpcConnection<P>
-  ): Promise<AutomaticCircleBridge<P>>;
-  getCircleBridge(rpc: RpcConnection<P>): Promise<CircleBridge<P>>;
 }

--- a/core/definitions/src/platform.ts
+++ b/core/definitions/src/platform.ts
@@ -9,16 +9,15 @@ import { TokenBridge, AutomaticTokenBridge } from "./protocols/tokenBridge";
 import { CircleBridge, AutomaticCircleBridge } from "./protocols/cctp";
 import { WormholeCore } from "./protocols/core";
 import { NativeAddress } from "./address";
-
-export type PlatformCtr<P extends PlatformName> = {
-  _platform: P;
-  new (conf: ChainsConfig): Platform<P>;
-};
+import { Contracts } from "./contracts";
 
 // Force passing RPC connection so we don't create a new one with every fn call
 export interface Platform<P extends PlatformName> {
   readonly platform: P;
   readonly conf: ChainsConfig;
+
+  init(_conf: ChainsConfig): Platform<P>;
+
   getChain(chain: ChainName): ChainContext<P>;
 
   // Utils for platform specific queries

--- a/core/definitions/src/protocols/cctp.ts
+++ b/core/definitions/src/protocols/cctp.ts
@@ -4,8 +4,36 @@ import { CircleMessageId } from "../attestation";
 import { UnsignedTransaction } from "../unsignedTransaction";
 import { TokenId, TxHash } from "../types";
 import "../payloads/connect";
+import { RpcConnection } from "../rpc";
 
 // https://github.com/circlefin/evm-cctp-contracts
+
+export interface SupportsCircleBridge<P extends PlatformName> {
+  getCircleBridge(rpc: RpcConnection<P>): Promise<CircleBridge<P>>;
+}
+
+export function supportsCircleBridge<P extends PlatformName>(
+  thing: SupportsCircleBridge<P> | any
+): thing is SupportsCircleBridge<P> {
+  return typeof (<SupportsCircleBridge<P>>thing).getCircleBridge === "function";
+}
+
+export interface SupportsAutomaticCircleBridge<P extends PlatformName> {
+  getAutomaticCircleBridge(
+    rpc: RpcConnection<P>
+  ): Promise<AutomaticCircleBridge<P>>;
+}
+
+export function supportsAutomaticCircleBridge<P extends PlatformName>(
+  thing: SupportsAutomaticCircleBridge<P> | any
+): thing is SupportsAutomaticCircleBridge<P> {
+  return (
+    (<SupportsAutomaticCircleBridge<P>>thing).getAutomaticCircleBridge !==
+      undefined &&
+    typeof (<SupportsAutomaticCircleBridge<P>>thing)
+      .getAutomaticCircleBridge === "function"
+  );
+}
 
 export type CircleTransferDetails = {
   txid: TxHash;

--- a/core/definitions/src/protocols/core.ts
+++ b/core/definitions/src/protocols/core.ts
@@ -1,6 +1,17 @@
 import { PlatformName } from "@wormhole-foundation/sdk-base";
 import { UniversalOrNative } from "../address";
 import { UnsignedTransaction } from "../unsignedTransaction";
+import { RpcConnection } from "../rpc";
+
+export interface SupportsWormholeCore<P extends PlatformName> {
+  getWormholeCore(rpc: RpcConnection<P>): Promise<WormholeCore<P>>;
+}
+
+export function supportsWormholeCore<P extends PlatformName>(
+  thing: SupportsWormholeCore<P> | any
+): thing is SupportsWormholeCore<P> {
+  return typeof (<SupportsWormholeCore<P>>thing).getWormholeCore === "function";
+}
 
 export interface WormholeCore<P extends PlatformName> {
   publishMessage(

--- a/core/definitions/src/protocols/tokenBridge.ts
+++ b/core/definitions/src/protocols/tokenBridge.ts
@@ -4,9 +4,37 @@ import { TokenId } from "../types";
 import { VAA } from "../vaa";
 import { UnsignedTransaction } from "../unsignedTransaction";
 import "../payloads/tokenBridge";
+import { RpcConnection } from "../rpc";
 
 export const ErrNotWrapped = (token: string) =>
   new Error(`Token ${token} is not a wrapped asset`);
+
+export interface SupportsTokenBridge<P extends PlatformName> {
+  getTokenBridge(rpc: RpcConnection<P>): Promise<TokenBridge<P>>;
+}
+
+export function supportsTokenBridge<P extends PlatformName>(
+  thing: SupportsTokenBridge<P> | any
+): thing is SupportsTokenBridge<P> {
+  return typeof (<SupportsTokenBridge<P>>thing).getTokenBridge === "function";
+}
+
+export interface SupportsAutomaticTokenBridge<P extends PlatformName> {
+  getAutomaticTokenBridge(
+    rpc: RpcConnection<P>
+  ): Promise<AutomaticTokenBridge<P>>;
+}
+
+export function supportsAutomaticTokenBridge<P extends PlatformName>(
+  thing: SupportsAutomaticTokenBridge<P> | any
+): thing is SupportsAutomaticTokenBridge<P> {
+  return (
+    (<SupportsAutomaticTokenBridge<P>>thing).getAutomaticTokenBridge !==
+      undefined &&
+    typeof (<SupportsAutomaticTokenBridge<P>>thing).getAutomaticTokenBridge ===
+      "function"
+  );
+}
 
 export interface TokenBridge<P extends PlatformName> {
   // checks a native address to see if its a wrapped version

--- a/core/definitions/src/rpc.ts
+++ b/core/definitions/src/rpc.ts
@@ -1,27 +1,2 @@
 import { PlatformName } from "@wormhole-foundation/sdk-base";
-
-export interface EvmRpc {
-  broadcastTransaction(stxns: string): Promise<any>;
-  getBalance(address: string): Promise<bigint>;
-}
-export interface SolanaRpc {
-  getBalance(publicKey: any, commitmentOrConfig: any): Promise<number>;
-  getParsedAccountInfo(publickKey: any): Promise<any>;
-}
-
-export interface CosmWasmRpc {
-  getBalance(address: string, searchDenom: string): Promise<any>;
-  broadcastTx(
-    tx: Uint8Array,
-    timeoutMs?: number,
-    pollIntervalMs?: number
-  ): Promise<any>;
-}
-
-export type RpcConnection<P extends PlatformName> = P extends "Evm"
-  ? EvmRpc
-  : P extends "Solana"
-  ? SolanaRpc
-  : P extends "Cosmwasm"
-  ? CosmWasmRpc
-  : never;
+export type RpcConnection<P extends PlatformName> = any;

--- a/core/definitions/src/testing/mocks/platform.ts
+++ b/core/definitions/src/testing/mocks/platform.ts
@@ -16,7 +16,6 @@ import {
   CircleBridge,
   AutomaticCircleBridge,
   ChainsConfig,
-  PlatformCtr,
   toNative,
   nativeIsRegistered,
   NativeAddress,
@@ -26,35 +25,29 @@ import { MockChain } from "./chain";
 import { MockTokenBridge } from "./tokenBridge";
 import { WormholeCore } from "../../protocols/core";
 
-export function mockPlatformFactory(
-  p: PlatformName
-): PlatformCtr<PlatformName> {
-  class ConcreteMockPlatform extends MockPlatform<typeof p> {
-    static _platform: typeof p = p;
-    readonly platform = ConcreteMockPlatform._platform;
-  }
-  return ConcreteMockPlatform;
+// TODO: how tf is this gonna work?
+export function mockPlatformFactory<P extends "Evm">(p: P): Platform<"Evm"> {
+  return MockPlatform;
 }
 
-// Note: don't use this directly, instead create a ConcreteMockPlatform with the
-// mockPlatformFactory
-export class MockPlatform<P extends PlatformName> implements Platform<P> {
-  // @ts-ignore
-  readonly platform: P;
+module MockPlatform {
+  export const platform: "Evm" = "Evm";
+  export let conf: ChainsConfig;
 
-  conf: ChainsConfig;
+  export type P = typeof platform;
 
-  constructor(conf: ChainsConfig) {
-    this.conf = conf;
+  export function init(_conf: ChainsConfig): Platform<P> {
+    conf = _conf;
+    return MockPlatform;
   }
-  getDecimals(
+  export function getDecimals(
     chain: ChainName,
     rpc: RpcConnection<P>,
     token: TokenId | "native"
   ): Promise<bigint> {
     throw new Error("Method not implemented.");
   }
-  getBalance(
+  export function getBalance(
     chain: ChainName,
     rpc: RpcConnection<P>,
     walletAddr: string,
@@ -63,34 +56,34 @@ export class MockPlatform<P extends PlatformName> implements Platform<P> {
     throw new Error("Method not implemented.");
   }
 
-  getChain(chain: ChainName): ChainContext<P> {
-    return new MockChain<P>(this, chain);
+  export function getChain(chain: ChainName): ChainContext<P> {
+    return new MockChain<P>(MockPlatform, chain);
   }
-  getRpc(chain: ChainName): RpcConnection<P> {
+  export function getRpc(chain: ChainName): RpcConnection<P> {
     // @ts-ignore
     return new MockRpc(chain);
   }
 
-  async getWrappedAsset(
+  export async function getWrappedAsset(
     chain: ChainName,
     rpc: RpcConnection<P>,
     token: TokenId
   ): Promise<TokenId | null> {
     throw new Error("Method not implemented.");
   }
-  async getTokenDecimals(
+  export async function getTokenDecimals(
     rpc: RpcConnection<P>,
     token: TokenId
   ): Promise<bigint> {
     return 8n;
   }
-  async getNativeBalance(
+  export async function getNativeBalance(
     rpc: RpcConnection<P>,
     walletAddr: string
   ): Promise<bigint> {
     return 0n;
   }
-  async getTokenBalance(
+  export async function getTokenBalance(
     chain: ChainName,
     rpc: RpcConnection<P>,
     walletAddr: string,
@@ -99,7 +92,7 @@ export class MockPlatform<P extends PlatformName> implements Platform<P> {
     return 10n;
   }
 
-  async parseTransaction(
+  export async function parseTransaction(
     chain: ChainName,
     rpc: RpcConnection<P>,
     txid: TxHash
@@ -107,13 +100,16 @@ export class MockPlatform<P extends PlatformName> implements Platform<P> {
     throw new Error("Method not implemented");
   }
 
-  parseAddress(chain: ChainName, address: string): NativeAddress<P> {
+  export function parseAddress(
+    chain: ChainName,
+    address: string
+  ): NativeAddress<P> {
     if (!nativeIsRegistered(chain)) throw new Error("Chain not registered");
     //@ts-ignore
     return toNative(chain, address).toUniversalAddress();
   }
 
-  async sendWait(
+  export async function sendWait(
     chain: ChainName,
     rpc: RpcConnection<P>,
     stxns: any[]
@@ -121,28 +117,34 @@ export class MockPlatform<P extends PlatformName> implements Platform<P> {
     throw new Error("Method not implemented.");
   }
 
-  async getWormholeCore(rpc: RpcConnection<P>): Promise<WormholeCore<P>> {
+  export async function getWormholeCore(
+    rpc: RpcConnection<P>
+  ): Promise<WormholeCore<P>> {
     throw new Error("Method not implemented.");
   }
-  async getTokenBridge(rpc: RpcConnection<P>): Promise<TokenBridge<P>> {
+  export async function getTokenBridge(
+    rpc: RpcConnection<P>
+  ): Promise<TokenBridge<P>> {
     // @ts-ignore
     return new MockTokenBridge<P>(rpc);
   }
 
-  async getAutomaticTokenBridge(
+  export async function getAutomaticTokenBridge(
     rpc: RpcConnection<P>
   ): Promise<AutomaticTokenBridge<P>> {
     throw new Error("Method not implemented.");
   }
-  async getCircleBridge(rpc: RpcConnection<P>): Promise<CircleBridge<P>> {
+  export async function getCircleBridge(
+    rpc: RpcConnection<P>
+  ): Promise<CircleBridge<P>> {
     throw new Error("Method not implemented.");
   }
-  async getCircleRelayer(
+  export async function getCircleRelayer(
     rpc: RpcConnection<P>
   ): Promise<AutomaticCircleBridge<P>> {
     throw new Error("Method Not implemented.");
   }
-  async getAutomaticCircleBridge(
+  export async function getAutomaticCircleBridge(
     rpc: RpcConnection<P>
   ): Promise<AutomaticCircleBridge<P>> {
     throw new Error("Method not implemented.");

--- a/core/definitions/src/testing/mocks/platform.ts
+++ b/core/definitions/src/testing/mocks/platform.ts
@@ -43,7 +43,7 @@ export class MockPlatform<P extends PlatformName> implements Platform<P> {
     this.conf = conf;
   }
 
-  init(conf: ChainsConfig): MockPlatform<P> {
+  setConfig(conf: ChainsConfig): MockPlatform<P> {
     this.conf = conf;
     return this;
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "connect",
     "platforms/evm",
     "platforms/solana",
-    "platforms/cosmwasm",
     "examples"
   ]
 }

--- a/platforms/evm/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/evm/__tests__/integration/tokenBridge.test.ts
@@ -112,7 +112,7 @@ const recipient: ChainAddress = {
 };
 
 describe('TokenBridge Tests', () => {
-  const p: Platform<'Evm'> = EvmPlatform.init(configs);
+  const p: Platform<'Evm'> = EvmPlatform.setConfig(configs);
   let tb: TokenBridge<'Evm'>;
 
   test('Create TokenBridge', async () => {

--- a/platforms/evm/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/evm/__tests__/integration/tokenBridge.test.ts
@@ -112,7 +112,7 @@ const recipient: ChainAddress = {
 };
 
 describe('TokenBridge Tests', () => {
-  const p: Platform<'Evm'> = new EvmPlatform(configs);
+  const p: Platform<'Evm'> = EvmPlatform.init(configs);
   let tb: TokenBridge<'Evm'>;
 
   test('Create TokenBridge', async () => {

--- a/platforms/evm/__tests__/unit/platform.test.ts
+++ b/platforms/evm/__tests__/unit/platform.test.ts
@@ -18,7 +18,7 @@ const configs = chainConfigs('Mainnet');
 
 describe('EVM Platform Tests', () => {
   describe('Parse Address', () => {
-    const p = new EvmPlatform({});
+    const p = EvmPlatform.init({});
     test.each(EVM_CHAINS)('Parses Address for %s', (chain: ChainName) => {
       const address = testing.utils.makeNativeAddressHexString(chain);
       const parsed = p.parseAddress(chain, address);
@@ -31,12 +31,12 @@ describe('EVM Platform Tests', () => {
 
   describe('Get Token Bridge', () => {
     test('No RPC', async () => {
-      const p = new EvmPlatform({});
+      const p = EvmPlatform;
       const rpc = getDefaultProvider('');
       expect(() => p.getTokenBridge(rpc)).rejects.toThrow();
     });
     test('With RPC', async () => {
-      const p = new EvmPlatform({
+      const p = EvmPlatform.init({
         [EVM_CHAINS[0]]: configs[EVM_CHAINS[0]],
       });
 
@@ -48,12 +48,12 @@ describe('EVM Platform Tests', () => {
 
   describe('Get Automatic Token Bridge', () => {
     test('No RPC', async () => {
-      const p = new EvmPlatform({});
+      const p = EvmPlatform.init({});
       const rpc = getDefaultProvider('');
       expect(() => p.getAutomaticTokenBridge(rpc)).rejects.toThrow();
     });
     test('With RPC', async () => {
-      const p = new EvmPlatform({
+      const p = EvmPlatform.init({
         [EVM_CHAINS[0]]: configs[EVM_CHAINS[0]],
       });
 
@@ -66,14 +66,14 @@ describe('EVM Platform Tests', () => {
   describe('Get Chain', () => {
     test('No conf', () => {
       // no issues just grabbing the chain
-      const p = new EvmPlatform({});
+      const p = EvmPlatform.init({});
       expect(p.conf).toEqual({});
       const c = p.getChain(EVM_CHAINS[0]);
       expect(c).toBeTruthy();
     });
 
     test('With conf', () => {
-      const p = new EvmPlatform({
+      const p = EvmPlatform.init({
         [EVM_CHAINS[0]]: configs[EVM_CHAINS[0]],
       });
       expect(() => p.getChain(EVM_CHAINS[0])).not.toThrow();
@@ -82,7 +82,7 @@ describe('EVM Platform Tests', () => {
 
   describe('Get RPC Connection', () => {
     test('No conf', () => {
-      const p = new EvmPlatform({});
+      const p = EvmPlatform.init({});
       expect(p.conf).toEqual({});
 
       // expect getRpc to throw an error since we havent provided
@@ -92,7 +92,7 @@ describe('EVM Platform Tests', () => {
     });
 
     test('With conf', () => {
-      const p = new EvmPlatform({
+      const p = EvmPlatform.init({
         [EVM_CHAINS[0]]: {
           rpc: 'http://localhost:8545',
         },

--- a/platforms/evm/__tests__/unit/platform.test.ts
+++ b/platforms/evm/__tests__/unit/platform.test.ts
@@ -18,7 +18,7 @@ const configs = chainConfigs('Mainnet');
 
 describe('EVM Platform Tests', () => {
   describe('Parse Address', () => {
-    const p = EvmPlatform.init({});
+    const p = EvmPlatform.setConfig({});
     test.each(EVM_CHAINS)('Parses Address for %s', (chain: ChainName) => {
       const address = testing.utils.makeNativeAddressHexString(chain);
       const parsed = p.parseAddress(chain, address);
@@ -36,7 +36,7 @@ describe('EVM Platform Tests', () => {
       expect(() => p.getTokenBridge(rpc)).rejects.toThrow();
     });
     test('With RPC', async () => {
-      const p = EvmPlatform.init({
+      const p = EvmPlatform.setConfig({
         [EVM_CHAINS[0]]: configs[EVM_CHAINS[0]],
       });
 
@@ -48,12 +48,12 @@ describe('EVM Platform Tests', () => {
 
   describe('Get Automatic Token Bridge', () => {
     test('No RPC', async () => {
-      const p = EvmPlatform.init({});
+      const p = EvmPlatform.setConfig({});
       const rpc = getDefaultProvider('');
       expect(() => p.getAutomaticTokenBridge(rpc)).rejects.toThrow();
     });
     test('With RPC', async () => {
-      const p = EvmPlatform.init({
+      const p = EvmPlatform.setConfig({
         [EVM_CHAINS[0]]: configs[EVM_CHAINS[0]],
       });
 
@@ -66,14 +66,14 @@ describe('EVM Platform Tests', () => {
   describe('Get Chain', () => {
     test('No conf', () => {
       // no issues just grabbing the chain
-      const p = EvmPlatform.init({});
+      const p = EvmPlatform.setConfig({});
       expect(p.conf).toEqual({});
       const c = p.getChain(EVM_CHAINS[0]);
       expect(c).toBeTruthy();
     });
 
     test('With conf', () => {
-      const p = EvmPlatform.init({
+      const p = EvmPlatform.setConfig({
         [EVM_CHAINS[0]]: configs[EVM_CHAINS[0]],
       });
       expect(() => p.getChain(EVM_CHAINS[0])).not.toThrow();
@@ -82,7 +82,7 @@ describe('EVM Platform Tests', () => {
 
   describe('Get RPC Connection', () => {
     test('No conf', () => {
-      const p = EvmPlatform.init({});
+      const p = EvmPlatform.setConfig({});
       expect(p.conf).toEqual({});
 
       // expect getRpc to throw an error since we havent provided
@@ -92,7 +92,7 @@ describe('EVM Platform Tests', () => {
     });
 
     test('With conf', () => {
-      const p = EvmPlatform.init({
+      const p = EvmPlatform.setConfig({
         [EVM_CHAINS[0]]: {
           rpc: 'http://localhost:8545',
         },

--- a/platforms/evm/src/platform.ts
+++ b/platforms/evm/src/platform.ts
@@ -15,6 +15,7 @@ import {
   NativeAddress,
   WormholeCore,
   CONFIG,
+  networkPlatformConfigs,
 } from '@wormhole-foundation/connect-sdk';
 
 import { ethers } from 'ethers';
@@ -35,17 +36,10 @@ const _: Platform<'Evm'> = EvmPlatform;
 // Provides runtime concrete value
 export module EvmPlatform {
   export const platform: 'Evm' = 'Evm';
+  export let conf: ChainsConfig = networkPlatformConfigs('Testnet', platform);
+  let contracts: EvmContracts = new EvmContracts(conf);
 
-  export let conf: ChainsConfig = Object.fromEntries(
-    // TODO: move to util fn
-    Object.entries(CONFIG['Mainnet'].chains).filter(([_, v]) => {
-      return v.platform == platform;
-    }),
-  );
-
-  export let contracts: EvmContracts = new EvmContracts(conf);
-
-  export function init(_conf: ChainsConfig): Platform<'Evm'> {
+  export function setConfig(_conf: ChainsConfig): Platform<'Evm'> {
     conf = _conf;
     contracts = new EvmContracts(conf);
     return EvmPlatform;

--- a/platforms/solana/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/solana/__tests__/integration/tokenBridge.test.ts
@@ -82,7 +82,7 @@ afterEach(async () => {
 });
 
 describe('TokenBridge Tests', () => {
-  const p: Platform<'Solana'> = SolanaPlatform.init(configs);
+  const p: Platform<'Solana'> = SolanaPlatform.setConfig(configs);
   let tb: TokenBridge<'Solana'>;
 
   test('Create TokenBridge', async () => {

--- a/platforms/solana/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/solana/__tests__/integration/tokenBridge.test.ts
@@ -82,7 +82,7 @@ afterEach(async () => {
 });
 
 describe('TokenBridge Tests', () => {
-  const p: Platform<'Solana'> = new SolanaPlatform(configs);
+  const p: Platform<'Solana'> = SolanaPlatform.init(configs);
   let tb: TokenBridge<'Solana'>;
 
   test('Create TokenBridge', async () => {

--- a/platforms/solana/__tests__/unit/platform.test.ts
+++ b/platforms/solana/__tests__/unit/platform.test.ts
@@ -21,7 +21,7 @@ const configs = chainConfigs('Mainnet');
 
 describe('Solana Platform Tests', () => {
   describe('Parse Address', () => {
-    const p = SolanaPlatform.init({});
+    const p = SolanaPlatform.setConfig({});
     test.each(SOLANA_CHAINS)('Parses Address for %s', (chain: ChainName) => {
       const address = testing.utils.makeNativeAddressHexString(chain);
       const parsed = p.parseAddress(chain, address);
@@ -36,7 +36,7 @@ describe('Solana Platform Tests', () => {
 
   describe('Get Token Bridge', () => {
     test('Hardcoded Genesis mock', async () => {
-      const p = SolanaPlatform.init({
+      const p = SolanaPlatform.setConfig({
         [SOLANA_CHAINS[0]]: configs[SOLANA_CHAINS[0]],
       });
       const tb = await p.getTokenBridge(fakeRpc);
@@ -46,7 +46,7 @@ describe('Solana Platform Tests', () => {
 
   describe('Get Automatic Token Bridge', () => {
     test('Fails until implemented', async () => {
-      const p = SolanaPlatform.init({
+      const p = SolanaPlatform.setConfig({
         [SOLANA_CHAINS[0]]: configs[SOLANA_CHAINS[0]],
       });
       expect(() => p.getAutomaticTokenBridge(fakeRpc)).rejects.toThrow();
@@ -56,14 +56,14 @@ describe('Solana Platform Tests', () => {
   describe('Get Chain', () => {
     test('No conf', () => {
       // no issues just grabbing the chain
-      const p = SolanaPlatform.init({});
+      const p = SolanaPlatform.setConfig({});
       expect(p.conf).toEqual({});
       const c = p.getChain(SOLANA_CHAINS[0]);
       expect(c).toBeTruthy();
     });
 
     test('With conf', () => {
-      const p = SolanaPlatform.init({
+      const p = SolanaPlatform.setConfig({
         [SOLANA_CHAINS[0]]: configs[SOLANA_CHAINS[0]],
       });
       expect(() => p.getChain(SOLANA_CHAINS[0])).not.toThrow();
@@ -72,7 +72,7 @@ describe('Solana Platform Tests', () => {
 
   describe('Get RPC Connection', () => {
     test('No conf', () => {
-      const p = SolanaPlatform.init({});
+      const p = SolanaPlatform.setConfig({});
       expect(p.conf).toEqual({});
 
       // expect getRpc to throw an error since we havent provided
@@ -82,7 +82,7 @@ describe('Solana Platform Tests', () => {
     });
 
     test('With conf', () => {
-      const p = SolanaPlatform.init({
+      const p = SolanaPlatform.setConfig({
         [SOLANA_CHAINS[0]]: {
           rpc: 'http://localhost:8545',
         },

--- a/platforms/solana/__tests__/unit/platform.test.ts
+++ b/platforms/solana/__tests__/unit/platform.test.ts
@@ -7,6 +7,7 @@ import {
   chainToPlatform,
   chains,
   chainConfigs,
+  supportsTokenBridge,
 } from '@wormhole-foundation/connect-sdk';
 
 import { SolanaPlatform } from '../../src';
@@ -39,19 +40,23 @@ describe('Solana Platform Tests', () => {
       const p = SolanaPlatform.setConfig({
         [SOLANA_CHAINS[0]]: configs[SOLANA_CHAINS[0]],
       });
+
+      if (!supportsTokenBridge(p))
+        throw new Error('Platform does not support TokenBridge');
+
       const tb = await p.getTokenBridge(fakeRpc);
       expect(tb).toBeTruthy();
     });
   });
 
-  describe('Get Automatic Token Bridge', () => {
-    test('Fails until implemented', async () => {
-      const p = SolanaPlatform.setConfig({
-        [SOLANA_CHAINS[0]]: configs[SOLANA_CHAINS[0]],
-      });
-      expect(() => p.getAutomaticTokenBridge(fakeRpc)).rejects.toThrow();
-    });
-  });
+  //describe('Get Automatic Token Bridge', () => {
+  //  test('Fails until implemented', async () => {
+  //    const p = SolanaPlatform.setConfig({
+  //      [SOLANA_CHAINS[0]]: configs[SOLANA_CHAINS[0]],
+  //    });
+  //    expect(() => p.getAutomaticTokenBridge(fakeRpc)).rejects.toThrow();
+  //  });
+  //});
 
   describe('Get Chain', () => {
     test('No conf', () => {

--- a/platforms/solana/__tests__/unit/platform.test.ts
+++ b/platforms/solana/__tests__/unit/platform.test.ts
@@ -21,7 +21,7 @@ const configs = chainConfigs('Mainnet');
 
 describe('Solana Platform Tests', () => {
   describe('Parse Address', () => {
-    const p = new SolanaPlatform({});
+    const p = SolanaPlatform.init({});
     test.each(SOLANA_CHAINS)('Parses Address for %s', (chain: ChainName) => {
       const address = testing.utils.makeNativeAddressHexString(chain);
       const parsed = p.parseAddress(chain, address);
@@ -36,7 +36,7 @@ describe('Solana Platform Tests', () => {
 
   describe('Get Token Bridge', () => {
     test('Hardcoded Genesis mock', async () => {
-      const p = new SolanaPlatform({
+      const p = SolanaPlatform.init({
         [SOLANA_CHAINS[0]]: configs[SOLANA_CHAINS[0]],
       });
       const tb = await p.getTokenBridge(fakeRpc);
@@ -46,7 +46,7 @@ describe('Solana Platform Tests', () => {
 
   describe('Get Automatic Token Bridge', () => {
     test('Fails until implemented', async () => {
-      const p = new SolanaPlatform({
+      const p = SolanaPlatform.init({
         [SOLANA_CHAINS[0]]: configs[SOLANA_CHAINS[0]],
       });
       expect(() => p.getAutomaticTokenBridge(fakeRpc)).rejects.toThrow();
@@ -56,14 +56,14 @@ describe('Solana Platform Tests', () => {
   describe('Get Chain', () => {
     test('No conf', () => {
       // no issues just grabbing the chain
-      const p = new SolanaPlatform({});
+      const p = SolanaPlatform.init({});
       expect(p.conf).toEqual({});
       const c = p.getChain(SOLANA_CHAINS[0]);
       expect(c).toBeTruthy();
     });
 
     test('With conf', () => {
-      const p = new SolanaPlatform({
+      const p = SolanaPlatform.init({
         [SOLANA_CHAINS[0]]: configs[SOLANA_CHAINS[0]],
       });
       expect(() => p.getChain(SOLANA_CHAINS[0])).not.toThrow();
@@ -72,7 +72,7 @@ describe('Solana Platform Tests', () => {
 
   describe('Get RPC Connection', () => {
     test('No conf', () => {
-      const p = new SolanaPlatform({});
+      const p = SolanaPlatform.init({});
       expect(p.conf).toEqual({});
 
       // expect getRpc to throw an error since we havent provided
@@ -82,7 +82,7 @@ describe('Solana Platform Tests', () => {
     });
 
     test('With conf', () => {
-      const p = new SolanaPlatform({
+      const p = SolanaPlatform.init({
         [SOLANA_CHAINS[0]]: {
           rpc: 'http://localhost:8545',
         },

--- a/platforms/solana/src/chain.ts
+++ b/platforms/solana/src/chain.ts
@@ -4,18 +4,17 @@ import {
   ChainContext,
   NativeAddress,
   RpcConnection,
-  TokenId,
   UniversalAddress,
   UniversalOrNative,
+  Platform,
 } from '@wormhole-foundation/connect-sdk';
-import { SolanaPlatform } from './platform';
 import { getAssociatedTokenAddress } from '@solana/spl-token';
 
 export class SolanaChain extends ChainContext<'Solana'> {
   // Cached objects
   private connection?: RpcConnection<'Solana'>;
 
-  constructor(platform: SolanaPlatform, chain: ChainName) {
+  constructor(platform: Platform<'Solana'>, chain: ChainName) {
     super(platform, chain);
   }
 

--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -15,13 +15,12 @@ import {
   toNative,
   NativeAddress,
   WormholeCore,
-  CONFIG,
+  networkPlatformConfigs,
 } from '@wormhole-foundation/connect-sdk';
 
 import { SolanaContracts } from './contracts';
 import { SolanaChain } from './chain';
 import { SolanaTokenBridge } from './protocols/tokenBridge';
-import { SolanaAddress } from './address';
 
 const SOLANA_SEQ_LOG = 'Program log: Sequence: ';
 
@@ -31,16 +30,10 @@ const _: Platform<'Solana'> = SolanaPlatform;
  */
 export module SolanaPlatform {
   export const platform: 'Solana' = 'Solana';
-  export let conf: ChainsConfig = Object.fromEntries(
-    // TODO: move to util fn
-    Object.entries(CONFIG['Mainnet'].chains).filter(([_, v]) => {
-      return v.platform == platform;
-    }),
-  );
+  export let conf: ChainsConfig = networkPlatformConfigs('Testnet', platform);
+  let contracts: SolanaContracts = new SolanaContracts(conf);
 
-  export let contracts: SolanaContracts = new SolanaContracts(conf);
-
-  export function init(_conf: ChainsConfig): Platform<'Solana'> {
+  export function setConfig(_conf: ChainsConfig): Platform<'Solana'> {
     conf = _conf;
     contracts = new SolanaContracts(conf);
     return SolanaPlatform;

--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -4,9 +4,6 @@ import {
   Platform,
   TokenId,
   TokenBridge,
-  AutomaticTokenBridge,
-  CircleBridge,
-  AutomaticCircleBridge,
   SignedTx,
   TxHash,
   WormholeMessageId,
@@ -14,7 +11,6 @@ import {
   ChainContext,
   toNative,
   NativeAddress,
-  WormholeCore,
   networkPlatformConfigs,
 } from '@wormhole-foundation/connect-sdk';
 
@@ -113,35 +109,10 @@ export module SolanaPlatform {
     return txhashes;
   }
 
-  export async function getWormholeCore(
-    rpc: Connection,
-  ): Promise<WormholeCore<'Solana'>> {
-    throw new Error('Not Supported');
-    //return SolanaWormholeCore.fromProvider(rpc, this.contracts);
-  }
-
   export async function getTokenBridge(
     rpc: Connection,
   ): Promise<TokenBridge<'Solana'>> {
     return SolanaTokenBridge.fromProvider(rpc, contracts);
-  }
-
-  export async function getAutomaticTokenBridge(
-    rpc: Connection,
-  ): Promise<AutomaticTokenBridge<'Solana'>> {
-    throw new Error('Not Supported');
-  }
-
-  export async function getCircleBridge(
-    rpc: Connection,
-  ): Promise<CircleBridge<'Solana'>> {
-    throw new Error('Not Supported');
-  }
-
-  export async function getAutomaticCircleBridge(
-    rpc: Connection,
-  ): Promise<AutomaticCircleBridge<'Solana'>> {
-    throw new Error('Not Supported');
   }
 
   export function parseAddress(


### PR DESCRIPTION
The current relationship between `Platform` and `ChainContext` is, in a word, bad.

This PR:
1) Changes `Platform` implementations from a class to a `module` that exports methods and values. 
2) Moves protocol client accessors (e.g. `getTokenBridge`) to their own interfaces with type guard methods
3) Modifies `ChainContext` now provides methods to check if the protocol is supported prior to trying to get them

The benefit is better structure and the ability to call platform specific methods without creating a new instance of a class and better handling of protocol support.

It also makes the Platform itself a sort of singleton who's config is updated across the runtime if modified. 

The downside is that it may be a strange pattern so the `MockPlatform` is still a class (that implements the `Platform` interface) 