### PR TITLE
Hardcode platform in ChainContext

### DIFF
--- a/core/definitions/src/chain.ts
+++ b/core/definitions/src/chain.ts
@@ -18,14 +18,20 @@ import { NativeAddress } from "./address";
 
 export abstract class ChainContext<P extends PlatformName> {
   // Cached Protocol clients
+  protected rpc?: RpcConnection<P>;
   protected tokenBridge?: TokenBridge<P>;
   protected autoTokenBridge?: AutomaticTokenBridge<P>;
   protected circleBridge?: CircleBridge<P>;
   protected autoCircleBridge?: AutomaticCircleBridge<P>;
 
-  constructor(readonly platform: Platform<P>, readonly chain: ChainName) {}
+  abstract platform: Platform<P>;
 
-  abstract getRpc(): RpcConnection<P>;
+  constructor(readonly chain: ChainName) {}
+
+  getRpc(): RpcConnection<P> {
+    this.rpc = this.rpc ? this.rpc : this.platform.getRpc(this.chain);
+    return this.rpc;
+  }
 
   // Get the number of decimals for a token
   async getDecimals(token: TokenId | "native"): Promise<bigint> {

--- a/core/definitions/src/testing/mocks/chain.ts
+++ b/core/definitions/src/testing/mocks/chain.ts
@@ -1,18 +1,18 @@
 import { ChainName, PlatformName } from "@wormhole-foundation/sdk-base";
 import { RpcConnection, ChainContext, Platform } from "../..";
+import { mockPlatformFactory } from "./platform";
 
 export function chainFactory<P extends PlatformName>(
   p: Platform<P>,
   chain: ChainName
 ): ChainContext<P> {
-  return new MockChain<P>(p, chain);
+  return new MockChain<P>(p.platform, chain);
 }
 
 export class MockChain<P extends PlatformName> extends ChainContext<P> {
-  private rpc?: RpcConnection<P>;
-
-  getRpc(): RpcConnection<P> {
-    this.rpc = this.rpc ? this.rpc : this.platform.getRpc(this.chain);
-    return this.rpc!;
+  readonly platform: Platform<P>;
+  constructor(platform: PlatformName, readonly chain: ChainName) {
+    super(chain);
+    this.platform = mockPlatformFactory<P>(platform as P, {});
   }
 }

--- a/core/definitions/src/testing/mocks/platform.ts
+++ b/core/definitions/src/testing/mocks/platform.ts
@@ -20,13 +20,12 @@ import { MockChain } from "./chain";
 import { MockTokenBridge } from "./tokenBridge";
 import { WormholeCore } from "../../protocols/core";
 
-export function mockPlatformFactory(
-  p: PlatformName,
+export function mockPlatformFactory<P extends PlatformName>(
+  p: P,
   config: ChainsConfig
-): Platform<PlatformName> {
-  class ConcreteMockPlatform extends MockPlatform<typeof p> {
-    static _platform: typeof p = p;
-    readonly platform = ConcreteMockPlatform._platform;
+): Platform<P> {
+  class ConcreteMockPlatform extends MockPlatform<P> {
+    readonly platform = p;
   }
   return new ConcreteMockPlatform(config);
 }
@@ -65,7 +64,7 @@ export class MockPlatform<P extends PlatformName> implements Platform<P> {
   }
 
   getChain(chain: ChainName): ChainContext<P> {
-    return new MockChain<P>(this, chain);
+    return new MockChain<P>(this.platform, chain);
   }
   getRpc(chain: ChainName): RpcConnection<P> {
     // @ts-ignore

--- a/platforms/evm/src/chain.ts
+++ b/platforms/evm/src/chain.ts
@@ -5,28 +5,8 @@ import {
   RpcConnection,
   ChainName,
 } from '@wormhole-foundation/connect-sdk';
+import { EvmPlatform } from './platform';
 
 export class EvmChain extends ChainContext<'Evm'> {
-  readonly chain: ChainName;
-  readonly platform: Platform<'Evm'>;
-  readonly conf: ChainConfig;
-
-  // Cached objects
-  private provider?: RpcConnection<'Evm'>;
-
-  constructor(platform: Platform<'Evm'>, chain: ChainName) {
-    super(platform, chain);
-
-    this.chain = chain;
-    this.conf = platform.conf[chain]!;
-    this.platform = platform;
-  }
-
-  getRpc(): RpcConnection<'Evm'> {
-    this.provider = this.provider
-      ? this.provider
-      : this.platform.getRpc(this.chain);
-
-    return this.provider!;
-  }
+  readonly platform: Platform<'Evm'> = EvmPlatform;
 }

--- a/platforms/evm/src/platform.ts
+++ b/platforms/evm/src/platform.ts
@@ -51,7 +51,7 @@ export module EvmPlatform {
   }
 
   export function getChain(chain: ChainName): EvmChain {
-    return new EvmChain(EvmPlatform, chain);
+    return new EvmChain(chain);
   }
 
   export function getWormholeCore(

--- a/platforms/solana/src/chain.ts
+++ b/platforms/solana/src/chain.ts
@@ -9,21 +9,10 @@ import {
   Platform,
 } from '@wormhole-foundation/connect-sdk';
 import { getAssociatedTokenAddress } from '@solana/spl-token';
+import { SolanaPlatform } from './platform';
 
 export class SolanaChain extends ChainContext<'Solana'> {
-  // Cached objects
-  private connection?: RpcConnection<'Solana'>;
-
-  constructor(platform: Platform<'Solana'>, chain: ChainName) {
-    super(platform, chain);
-  }
-
-  getRpc(): RpcConnection<'Solana'> {
-    this.connection = this.connection
-      ? this.connection
-      : this.platform.getRpc(this.chain);
-    return this.connection!;
-  }
+  readonly platform: Platform<'Solana'> = SolanaPlatform;
 
   async getTokenAccount(
     token: UniversalOrNative<'Solana'> | 'native',

--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -44,7 +44,7 @@ export module SolanaPlatform {
   }
 
   export function getChain(chain: ChainName): ChainContext<'Solana'> {
-    return new SolanaChain(SolanaPlatform, chain);
+    return new SolanaChain(chain);
   }
 
   export async function getDecimals(


### PR DESCRIPTION
This changes the ChainContext constructor to avoid passing in the module like a value.

Instead, since we're relying on the platform and we know what platform we want to use, we provide it in the concrete implementation.

