### PR TITLE
Fix gnosis testnet chain id

### DIFF
--- a/platforms/evm/src/constants.ts
+++ b/platforms/evm/src/constants.ts
@@ -50,7 +50,7 @@ const networkChainEvmCIdEntries = [
       ['Neon', 245022940n],
       ['Arbitrum', 421613n], //arbitrum goerli
       ['Optimism', 420n],
-      ['Gnosis', 77n],
+      ['Gnosis', 10200n],
       ['Base', 84531n],
       ['Rootstock', 31n],
     ],


### PR DESCRIPTION
![image](https://github.com/wormhole-foundation/connect-sdk/assets/520236/439f1cc0-8cdc-4eff-ba95-4f21be2fcc12)

https://chainlist.org/?search=gnosis&testnets=true