### PR TITLE
Use signed_vaa endpoint on getVaaBytes

### DIFF
--- a/connect/__tests__/index.test.ts
+++ b/connect/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import * as publicRpcMock from './mocks/publicrpc';
 import {
   TokenBridge,
   Platform,
@@ -34,6 +35,25 @@ describe('Wormhole Tests', () => {
   test('returns chain', async () => {
     c = wh.getChain('Ethereum');
     expect(c).toBeTruthy();
+  });
+
+  describe('getVAABytes', () => {
+    test('returns vaa bytes', async () => {
+      const vaa = await wh.getVAABytes('Arbitrum', testing.utils.makeChainAddress('Arbitrum').address, 1n);
+      expect(vaa).toBeDefined();
+    });
+
+    test('returns undefined when vaa bytes not found', async () => {
+      publicRpcMock.givenSignedVaaNotFound();
+      const vaa = await wh.getVAABytes('Aptos', testing.utils.makeChainAddress('Aptos').address, 1n, 1);
+      expect(vaa).toBeUndefined();
+    });
+
+    test('returns after first try fails', async () => {
+      publicRpcMock.givenSignedVaaRequestWorksAfterRetry();
+      const vaa = await wh.getVAABytes('Base', testing.utils.makeChainAddress('Base').address, 1n, 2, { retryDelay: 10 });
+      expect(vaa).toBeDefined();
+    });
   });
 });
 

--- a/connect/__tests__/mocks/publicrpc.ts
+++ b/connect/__tests__/mocks/publicrpc.ts
@@ -1,0 +1,37 @@
+const vaaBytes = "AQAAAAABAFF+Nf18NSYNieW1ScgE+mB8aQwT38tJfMhfcP9tpIvINkjrdoXQHDRdFvBoLU0e9ubPDXCJ5cfstpBv7Oa/WecAZSV4BAAAAAAACGJB/9wDK2k7+4VEhY8EA97Iby4XIK+fNPjWX+V0tiOMAAAAAAAAF2EAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADJ6zttAAAAAAAAAAAAAAAAu98b+5NUusWMNKhaKUmCvK8+XJwAAgAAAAAAAAAAAAAAAIVCzopf6Qwm6UA2xnYjuVOvQ+dyAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+const sucessfulResponse = {
+    status: 200,
+    data: {
+        vaaBytes,
+    }
+};
+
+const notFoundResponse = {
+    status: 404,
+    data: {
+        code: 5,
+        message: "requested VAA not found in store",
+        details: []
+    }
+};
+
+let nextGet: jest.Mock = jest.fn().mockResolvedValue(sucessfulResponse);
+
+jest.mock('axios', () => {
+    const actualAxios = jest.requireActual('axios');
+
+    return {
+        ...actualAxios,
+        get: () => nextGet()
+    };
+});
+
+export const givenSignedVaaNotFound = () => {
+    nextGet = jest.fn().mockRejectedValue(notFoundResponse);
+};
+
+export const givenSignedVaaRequestWorksAfterRetry = () => {
+    nextGet = jest.fn()
+        .mockRejectedValueOnce(notFoundResponse)
+        .mockResolvedValueOnce(sucessfulResponse);
+};

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -23,7 +23,7 @@ import {
   WormholeMessageId,
   isTokenId,
 } from "@wormhole-foundation/sdk-definitions";
-import axios, { AxiosResponse } from "axios";
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 
 import { WormholeConfig } from "./types";
 
@@ -383,6 +383,7 @@ export class Wormhole {
    * @param emitter The emitter address
    * @param sequence The sequence number
    * @param retries The number of times to retry
+   * @param opts The options for the request. Timeouts must be set in ms.
    * @returns The VAA bytes if available
    * @throws Errors if the VAA is not available after the retries
    */
@@ -391,15 +392,28 @@ export class Wormhole {
     emitter: UniversalAddress | NativeAddress<PlatformName>,
     sequence: bigint,
     retries: number = 5,
+    opts?: {
+      retryDelay?: number;
+      requestTimeout?: number;
+    },
   ): Promise<Uint8Array | undefined> {
     const chainId = toChainId(chain);
-    const emitterAddress = emitter.toUniversalAddress().toString();
+    const universalAddress = emitter.toUniversalAddress().toString();
+    const emitterAddress = universalAddress.startsWith("0x")
+      ? universalAddress.slice(2)
+      : universalAddress;
 
     let response: AxiosResponse<any, any> | undefined;
-    const url = `${this.conf.api}/api/v1/vaas/${chainId}/${emitterAddress}/${sequence}`;
+    const url = `${this.conf.api}/v1/signed_vaa/${chainId}/${emitterAddress}/${sequence}`;
+    const axiosOptions: AxiosRequestConfig = {};
+    if (opts?.requestTimeout) {
+      axiosOptions.timeout = opts.requestTimeout;
+      axiosOptions.signal = AbortSignal.timeout(opts.requestTimeout);
+    }
 
     for (let i = retries; i > 0 && !response; i--) {
-      if (i != retries) await new Promise((f) => setTimeout(f, 2000));
+      if (i != retries)
+        await new Promise((f) => setTimeout(f, opts?.retryDelay ?? 2000));
 
       try {
         response = await axios.get(url);
@@ -411,11 +425,7 @@ export class Wormhole {
 
     const { data } = response;
 
-    return new Uint8Array(Buffer.from(data.data.vaa, "base64"));
-
-    // TODO: Make both data formats work
-    // const url = `https://wormhole-v2-testnet-api.certus.one/v1/signed_vaa/${chainId}/${emitterAddress}/${sequence}`;
-    //return new Uint8Array(Buffer.from(data.vaaBytes, 'base64'));
+    return new Uint8Array(Buffer.from(data.vaaBytes, "base64"));
   }
 
   /**


### PR DESCRIPTION
- Uses signed_vaa endpoint, which is also available in wormholescan.
- Adds options to set timeouts.