### PR TITLE
add: optimized get token balances

### DIFF
--- a/core/definitions/src/platform.ts
+++ b/core/definitions/src/platform.ts
@@ -22,7 +22,7 @@ export interface PlatformUtils<P extends PlatformName> {
   getDecimals(
     chain: ChainName,
     rpc: RpcConnection<P>,
-    token: AnyAddress | "native",
+    token: AnyAddress,
   ): Promise<bigint>;
   getBalance(
     chain: ChainName,

--- a/core/definitions/src/platform.ts
+++ b/core/definitions/src/platform.ts
@@ -7,7 +7,8 @@ import { NativeAddress } from "./address";
 import { WormholeMessageId } from "./attestation";
 import { ChainContext } from "./chain";
 import { RpcConnection } from "./rpc";
-import { ChainsConfig, SignedTx, TokenId, TxHash } from "./types";
+import { AnyAddress, Balances, ChainsConfig, TokenId, TxHash } from "./types";
+import { SignedTx } from "./types";
 import { UniversalAddress } from "./universalAddress";
 
 export interface PlatformUtils<P extends PlatformName> {
@@ -27,8 +28,14 @@ export interface PlatformUtils<P extends PlatformName> {
     chain: ChainName,
     rpc: RpcConnection<P>,
     walletAddr: string,
-    token: NativeAddress<P> | UniversalAddress | "native",
+    token: AnyAddress,
   ): Promise<bigint | null>;
+  getBalances(
+    chain: ChainName,
+    rpc: RpcConnection<P>,
+    walletAddress: string,
+    tokens: AnyAddress[],
+  ): Promise<Balances>;
   getCurrentBlock(rpc: RpcConnection<P>): Promise<number>;
 
   // Platform interaction utils

--- a/core/definitions/src/platform.ts
+++ b/core/definitions/src/platform.ts
@@ -22,7 +22,7 @@ export interface PlatformUtils<P extends PlatformName> {
   getDecimals(
     chain: ChainName,
     rpc: RpcConnection<P>,
-    token: NativeAddress<P> | UniversalAddress | "native",
+    token: AnyAddress | "native",
   ): Promise<bigint>;
   getBalance(
     chain: ChainName,

--- a/core/definitions/src/protocols/cctp.ts
+++ b/core/definitions/src/protocols/cctp.ts
@@ -5,12 +5,12 @@ import {
   deserializeLayout,
   uint8ArrayToHexByteString,
 } from "@wormhole-foundation/sdk-base";
-import { ChainAddress, UniversalOrNative } from "../address";
+import { ChainAddress } from "../address";
 import { CircleMessageId } from "../attestation";
 import { universalAddressItem } from "../layout-items";
 import "../payloads/connect";
 import { RpcConnection } from "../rpc";
-import { TokenId } from "../types";
+import { AnyAddress, TokenId } from "../types";
 import { UnsignedTransaction } from "../unsignedTransaction";
 import { keccak256 } from "../utils";
 
@@ -55,7 +55,7 @@ export type CircleTransferMessage = {
 export interface AutomaticCircleBridge<P extends PlatformName> {
   transfer(
     token: ChainAddress,
-    sender: UniversalOrNative<P>,
+    sender: AnyAddress,
     recipient: ChainAddress,
     amount: bigint,
     nativeGas?: bigint,
@@ -66,13 +66,13 @@ export interface AutomaticCircleBridge<P extends PlatformName> {
 // https://github.com/circlefin/evm-cctp-contracts
 export interface CircleBridge<P extends PlatformName> {
   redeem(
-    sender: UniversalOrNative<P>,
+    sender: AnyAddress,
     message: string,
     attestation: string,
   ): AsyncGenerator<UnsignedTransaction>;
   transfer(
     token: ChainAddress,
-    sender: UniversalOrNative<P>,
+    sender: AnyAddress,
     recipient: ChainAddress,
     amount: bigint,
   ): AsyncGenerator<UnsignedTransaction>;

--- a/core/definitions/src/protocols/core.ts
+++ b/core/definitions/src/protocols/core.ts
@@ -1,5 +1,5 @@
 import { PlatformName } from "@wormhole-foundation/sdk-base";
-import { UniversalOrNative } from "../address";
+import { AnyAddress } from "../types";
 import { UnsignedTransaction } from "../unsignedTransaction";
 import { RpcConnection } from "../rpc";
 
@@ -15,7 +15,7 @@ export function supportsWormholeCore<P extends PlatformName>(
 
 export interface WormholeCore<P extends PlatformName> {
   publishMessage(
-    sender: UniversalOrNative<P>,
+    sender: AnyAddress,
     message: string | Uint8Array
   ): AsyncGenerator<UnsignedTransaction>;
   // TODO: parseTransactionDetails

--- a/core/definitions/src/protocols/ibc.ts
+++ b/core/definitions/src/protocols/ibc.ts
@@ -211,7 +211,7 @@ export interface IbcBridge<P extends PlatformName> {
   transfer(
     sender: AnyAddress,
     recipient: ChainAddress,
-    token: AnyAddress | "native",
+    token: AnyAddress,
     amount: bigint,
     payload?: Uint8Array,
   ): AsyncGenerator<UnsignedTransaction>;

--- a/core/definitions/src/protocols/ibc.ts
+++ b/core/definitions/src/protocols/ibc.ts
@@ -4,10 +4,10 @@ import {
   PlatformName,
   toChainId,
 } from "@wormhole-foundation/sdk-base";
-import { ChainAddress, NativeAddress, UniversalOrNative } from "../address";
+import { ChainAddress, NativeAddress } from "../address";
 import { IbcMessageId, WormholeMessageId } from "../attestation";
 import { RpcConnection } from "../rpc";
-import { TokenId, TxHash } from "../types";
+import { AnyAddress, TokenId, TxHash } from "../types";
 import { UnsignedTransaction } from "../unsignedTransaction";
 
 // Configuration for a transfer through the Gateway
@@ -209,9 +209,9 @@ export function supportsIbcBridge<P extends PlatformName>(
 export interface IbcBridge<P extends PlatformName> {
   //alternative naming: initiateTransfer
   transfer(
-    sender: UniversalOrNative<P>,
+    sender: AnyAddress,
     recipient: ChainAddress,
-    token: UniversalOrNative<P> | "native",
+    token: AnyAddress | "native",
     amount: bigint,
     payload?: Uint8Array,
   ): AsyncGenerator<UnsignedTransaction>;

--- a/core/definitions/src/protocols/tokenBridge.ts
+++ b/core/definitions/src/protocols/tokenBridge.ts
@@ -1,6 +1,6 @@
 import { PlatformName } from "@wormhole-foundation/sdk-base";
-import { UniversalOrNative, NativeAddress, ChainAddress } from "../address";
-import { TokenId } from "../types";
+import { NativeAddress, ChainAddress } from "../address";
+import { AnyAddress, TokenId } from "../types";
 import { VAA } from "../vaa";
 import { UnsignedTransaction } from "../unsignedTransaction";
 import "../payloads/tokenBridge";
@@ -36,9 +36,9 @@ export function supportsAutomaticTokenBridge<P extends PlatformName>(
 
 export interface TokenBridge<P extends PlatformName> {
   // checks a native address to see if its a wrapped version
-  isWrappedAsset(nativeAddress: UniversalOrNative<P>): Promise<boolean>;
+  isWrappedAsset(nativeAddress: AnyAddress): Promise<boolean>;
   // returns the original asset with its foreign chain
-  getOriginalAsset(nativeAddress: UniversalOrNative<P>): Promise<TokenId>;
+  getOriginalAsset(nativeAddress: AnyAddress): Promise<TokenId>;
   // returns the wrapped version of the native asset
   getWrappedNative(): Promise<NativeAddress<P>>;
 
@@ -53,24 +53,24 @@ export interface TokenBridge<P extends PlatformName> {
   ): Promise<boolean>;
   //signer required:
   createAttestation(
-    token_to_attest: UniversalOrNative<P>,
-    payer?: UniversalOrNative<P>
+    token_to_attest: AnyAddress,
+    payer?: AnyAddress
   ): AsyncGenerator<UnsignedTransaction>;
   submitAttestation(
     vaa: VAA<"AttestMeta">,
-    payer?: UniversalOrNative<P>
+    payer?: AnyAddress
   ): AsyncGenerator<UnsignedTransaction>;
   //alternative naming: initiateTransfer
   transfer(
-    sender: UniversalOrNative<P>,
+    sender: AnyAddress,
     recipient: ChainAddress,
-    token: UniversalOrNative<P> | "native",
+    token: AnyAddress | "native",
     amount: bigint,
     payload?: Uint8Array
   ): AsyncGenerator<UnsignedTransaction>;
   //alternative naming: completeTransfer
   redeem(
-    sender: UniversalOrNative<P>,
+    sender: AnyAddress,
     vaa: VAA<"Transfer"> | VAA<"TransferWithPayload">,
     unwrapNative?: boolean //default: true
   ): AsyncGenerator<UnsignedTransaction>;
@@ -79,15 +79,15 @@ export interface TokenBridge<P extends PlatformName> {
 
 export interface AutomaticTokenBridge<P extends PlatformName> {
   transfer(
-    sender: UniversalOrNative<P>,
+    sender: AnyAddress,
     recipient: ChainAddress,
-    token: UniversalOrNative<P> | "native",
+    token: AnyAddress | "native",
     amount: bigint,
     relayerFee: bigint,
     nativeGas?: bigint
   ): AsyncGenerator<UnsignedTransaction>;
   redeem(
-    sender: UniversalOrNative<P>,
+    sender: AnyAddress,
     vaa: VAA<"TransferWithPayload">
   ): AsyncGenerator<UnsignedTransaction>;
   getRelayerFee(

--- a/core/definitions/src/protocols/tokenBridge.ts
+++ b/core/definitions/src/protocols/tokenBridge.ts
@@ -64,7 +64,7 @@ export interface TokenBridge<P extends PlatformName> {
   transfer(
     sender: AnyAddress,
     recipient: ChainAddress,
-    token: AnyAddress | "native",
+    token: AnyAddress,
     amount: bigint,
     payload?: Uint8Array
   ): AsyncGenerator<UnsignedTransaction>;
@@ -81,7 +81,7 @@ export interface AutomaticTokenBridge<P extends PlatformName> {
   transfer(
     sender: AnyAddress,
     recipient: ChainAddress,
-    token: AnyAddress | "native",
+    token: AnyAddress,
     amount: bigint,
     relayerFee: bigint,
     nativeGas?: bigint

--- a/core/definitions/src/relayer.ts
+++ b/core/definitions/src/relayer.ts
@@ -1,19 +1,19 @@
 import { Chain, PlatformName } from "@wormhole-foundation/sdk-base";
-import { UniversalOrNative } from "./address";
+import { AnyAddress } from "./types";
 
 export interface Relayer<P extends PlatformName> {
   relaySupported(chain: Chain): boolean;
   getRelayerFee(
     sourceChain: Chain,
     destChain: Chain,
-    tokenId: UniversalOrNative<P>,
+    tokenId: AnyAddress,
   ): Promise<bigint>;
   // TODO: What should this be named?
   // I don't think it should return an UnisgnedTransaction
   // rather it should take some signing callbacks and
   // a ref to track the progress
   startTransferWithRelay(
-    token: UniversalOrNative<P> | "native",
+    token: AnyAddress | "native",
     amount: bigint,
     toNativeToken: string,
     sendingChain: Chain,
@@ -24,13 +24,13 @@ export interface Relayer<P extends PlatformName> {
   ): Promise<any>;
   calculateNativeTokenAmt(
     destChain: Chain,
-    tokenId: UniversalOrNative<P>,
+    tokenId: AnyAddress,
     amount: bigint,
     walletAddress: string,
   ): Promise<bigint>;
   calculateMaxSwapAmount(
     destChain: Chain,
-    tokenId: UniversalOrNative<P>,
+    tokenId: AnyAddress,
     walletAddress: string,
   ): Promise<bigint>;
 }

--- a/core/definitions/src/relayer.ts
+++ b/core/definitions/src/relayer.ts
@@ -13,7 +13,7 @@ export interface Relayer<P extends PlatformName> {
   // rather it should take some signing callbacks and
   // a ref to track the progress
   startTransferWithRelay(
-    token: AnyAddress | "native",
+    token: AnyAddress,
     amount: bigint,
     toNativeToken: string,
     sendingChain: Chain,

--- a/core/definitions/src/testing/mocks/platform.ts
+++ b/core/definitions/src/testing/mocks/platform.ts
@@ -92,7 +92,7 @@ export class MockPlatform<P extends PlatformName> implements Platform<P> {
     walletAddress: string,
     tokens: AnyAddress[],
   ): Promise<Balances> {
-    throw new Error("method not implemented")
+    throw new Error("method not implemented");
   }
 
   getChain(chain: ChainName): ChainContext<P> {

--- a/core/definitions/src/testing/mocks/platform.ts
+++ b/core/definitions/src/testing/mocks/platform.ts
@@ -19,6 +19,8 @@ import {
   nativeIsRegistered,
   NativeAddress,
   UniversalAddress,
+  AnyAddress,
+  Balances,
 } from "../..";
 import { MockRpc } from "./rpc";
 import { MockChain } from "./chain";
@@ -82,6 +84,15 @@ export class MockPlatform<P extends PlatformName> implements Platform<P> {
     token: NativeAddress<P> | UniversalAddress | "native",
   ): Promise<bigint | null> {
     throw new Error("Method not implemented.");
+  }
+
+  getBalances(
+    chain: ChainName,
+    rpc: RpcConnection<PlatformName>,
+    walletAddress: string,
+    tokens: AnyAddress[],
+  ): Promise<Balances> {
+    throw new Error("method not implemented")
   }
 
   getChain(chain: ChainName): ChainContext<P> {

--- a/core/definitions/src/testing/mocks/tokenBridge.ts
+++ b/core/definitions/src/testing/mocks/tokenBridge.ts
@@ -1,11 +1,10 @@
 import { PlatformName } from "@wormhole-foundation/sdk-base";
 import {
+  AnyAddress,
   ChainAddress,
   NativeAddress,
   RpcConnection,
   TokenBridge,
-  TokenId,
-  UniversalOrNative,
   UnsignedTransaction,
   VAA,
 } from "../..";
@@ -19,10 +18,10 @@ import {
 export class MockTokenBridge<P extends PlatformName> implements TokenBridge<P> {
   constructor(readonly rpc: RpcConnection<P>) {}
 
-  isWrappedAsset(token: UniversalOrNative<P>): Promise<boolean> {
+  isWrappedAsset(token: AnyAddress): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
-  getOriginalAsset(token: UniversalOrNative<P>): Promise<ChainAddress> {
+  getOriginalAsset(token: AnyAddress): Promise<ChainAddress> {
     throw new Error("Method not implemented.");
   }
   hasWrappedAsset(original: ChainAddress): Promise<boolean> {
@@ -37,7 +36,7 @@ export class MockTokenBridge<P extends PlatformName> implements TokenBridge<P> {
     throw new Error("Method not implemented.");
   }
   createAttestation(
-    address: UniversalOrNative<P>,
+    address: AnyAddress,
   ): AsyncGenerator<UnsignedTransaction> {
     throw new Error("Method not implemented.");
   }
@@ -47,16 +46,16 @@ export class MockTokenBridge<P extends PlatformName> implements TokenBridge<P> {
     throw new Error("Method not implemented.");
   }
   transfer(
-    sender: UniversalOrNative<P>,
+    sender: AnyAddress,
     recipient: ChainAddress,
-    token: "native" | UniversalOrNative<P>,
+    token: "native" | AnyAddress,
     amount: bigint,
     payload?: Uint8Array | undefined,
   ): AsyncGenerator<UnsignedTransaction> {
     throw new Error("Method not implemented.");
   }
   redeem(
-    sender: UniversalOrNative<P>,
+    sender: AnyAddress,
     vaa: VAA<"Transfer"> | VAA<"TransferWithPayload">,
     unwrapNative?: boolean | undefined,
   ): AsyncGenerator<UnsignedTransaction> {

--- a/core/definitions/src/testing/mocks/tokenBridge.ts
+++ b/core/definitions/src/testing/mocks/tokenBridge.ts
@@ -35,9 +35,7 @@ export class MockTokenBridge<P extends PlatformName> implements TokenBridge<P> {
   ): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
-  createAttestation(
-    address: AnyAddress,
-  ): AsyncGenerator<UnsignedTransaction> {
+  createAttestation(address: AnyAddress): AsyncGenerator<UnsignedTransaction> {
     throw new Error("Method not implemented.");
   }
   submitAttestation(

--- a/core/definitions/src/types.ts
+++ b/core/definitions/src/types.ts
@@ -16,7 +16,14 @@ export type SequenceId = bigint;
 export type SignedTx = any;
 
 // TODO: Can we make this more dynamic?
-export type AnyAddress = NativeAddress<PlatformName> | UniversalAddress | string | number | Uint8Array | number[] | "native";
+export type AnyAddress =
+  | NativeAddress<PlatformName>
+  | UniversalAddress
+  | string
+  | number
+  | Uint8Array
+  | number[]
+  | "native";
 
 export type TokenId = ChainAddress;
 export function isTokenId(thing: TokenId | any): thing is TokenId {
@@ -28,7 +35,7 @@ export function isTokenId(thing: TokenId | any): thing is TokenId {
 
 export type Balances = {
   [key: string]: BigInt | null;
-}
+};
 
 export interface Signer {
   chain(): ChainName;

--- a/core/definitions/src/types.ts
+++ b/core/definitions/src/types.ts
@@ -15,15 +15,13 @@ export type SequenceId = bigint;
 
 export type SignedTx = any;
 
-// TODO: Can we make this more dynamic?
 export type AnyAddress =
   | NativeAddress<PlatformName>
   | UniversalAddress
   | string
   | number
   | Uint8Array
-  | number[]
-  | "native";
+  | number[];
 
 export type TokenId = ChainAddress;
 export function isTokenId(thing: TokenId | any): thing is TokenId {

--- a/core/definitions/src/types.ts
+++ b/core/definitions/src/types.ts
@@ -15,12 +15,19 @@ export type SequenceId = bigint;
 
 export type SignedTx = any;
 
+// TODO: Can we make this more dynamic?
+export type AnyAddress = NativeAddress<PlatformName> | UniversalAddress | string | number | Uint8Array | number[] | "native";
+
 export type TokenId = ChainAddress;
 export function isTokenId(thing: TokenId | any): thing is TokenId {
   return (
     typeof (<TokenId>thing).address !== undefined &&
     isChain((<TokenId>thing).chain)
   );
+}
+
+export type Balances = {
+  [key: string]: BigInt | null;
 }
 
 export interface Signer {

--- a/core/definitions/src/universalAddress.ts
+++ b/core/definitions/src/universalAddress.ts
@@ -8,6 +8,7 @@ import { Address, NativeAddress, toNative } from "./address";
 
 export class UniversalAddress implements Address {
   static readonly byteSize = 32;
+  private readonly type = 'Universal';
 
   private readonly address: Uint8Array;
 
@@ -45,7 +46,7 @@ export class UniversalAddress implements Address {
   }
 
   equals(other: UniversalAddress): boolean {
-    if (other instanceof UniversalAddress) {
+    if (UniversalAddress.instanceof(other)) {
       return other.toString() === this.toString();
     }
     return false;
@@ -53,5 +54,9 @@ export class UniversalAddress implements Address {
 
   static isValidAddress(address: string) {
     return isHexByteString(address, UniversalAddress.byteSize);
+  }
+
+  static instanceof(address: any) {
+    return address.type === 'Universal';
   }
 }

--- a/core/definitions/src/universalAddress.ts
+++ b/core/definitions/src/universalAddress.ts
@@ -8,7 +8,7 @@ import { Address, NativeAddress, toNative } from "./address";
 
 export class UniversalAddress implements Address {
   static readonly byteSize = 32;
-  private readonly type = 'Universal';
+  private readonly type = "Universal";
 
   private readonly address: Uint8Array;
 
@@ -57,6 +57,6 @@ export class UniversalAddress implements Address {
   }
 
   static instanceof(address: any) {
-    return address.type === 'Universal';
+    return address.type === "Universal";
   }
 }

--- a/platforms/cosmwasm/__tests__/unit/platform.test.ts
+++ b/platforms/cosmwasm/__tests__/unit/platform.test.ts
@@ -2,8 +2,6 @@ import { expect, test } from "@jest/globals";
 import {
   chains,
   chainConfigs,
-  DEFAULT_NETWORK,
-  chainToPlatform,
 } from "@wormhole-foundation/connect-sdk";
 import { CosmwasmPlatform } from "../../src/platform";
 

--- a/platforms/cosmwasm/src/address.ts
+++ b/platforms/cosmwasm/src/address.ts
@@ -1,6 +1,7 @@
 import { toBech32, fromBech32, fromHex, fromBase64 } from "@cosmjs/encoding";
 import {
   Address,
+  PlatformName,
   UniversalAddress,
   registerNative,
 } from "@wormhole-foundation/connect-sdk";
@@ -103,6 +104,7 @@ function tryDecode(data: string): { data: Uint8Array; prefix?: string } {
 export class CosmwasmAddress implements Address {
   static readonly contractAddressByteSize = 32;
   static readonly accountAddressByteSize = 20;
+  static readonly platform: PlatformName = 'Cosmwasm';
 
   // the actual bytes of the address
   private readonly address: Uint8Array;
@@ -115,8 +117,13 @@ export class CosmwasmAddress implements Address {
   private readonly denomType?: string;
 
   constructor(address: AnyCosmwasmAddress) {
-    if (address instanceof CosmwasmAddress) {
-      Object.assign(this, address);
+    if (CosmwasmAddress.instanceof(address)) {
+      const a = address as unknown as CosmwasmAddress;
+      this.address = a.address;
+      this.domain = a.domain;
+      this.denom = a.denom;
+      this.denomType = a.denomType;
+      return;
     }
     if (typeof address === "string") {
       // A native denom like "uatom"
@@ -156,7 +163,7 @@ export class CosmwasmAddress implements Address {
       }
     } else if (address instanceof Uint8Array) {
       this.address = address;
-    } else if (address instanceof UniversalAddress) {
+    } else if (UniversalAddress.instanceof(address)) {
       this.address = address.toUint8Array();
     } else throw new Error(`Invalid Cosmwasm address ${address}`);
 
@@ -226,6 +233,10 @@ export class CosmwasmAddress implements Address {
       );
 
     return true;
+  }
+
+  static instanceof(address: any) {
+    return address.platform === CosmwasmAddress.platform;
   }
 
   equals(other: UniversalAddress): boolean {

--- a/platforms/cosmwasm/src/address.ts
+++ b/platforms/cosmwasm/src/address.ts
@@ -1,7 +1,6 @@
 import { toBech32, fromBech32, fromHex, fromBase64 } from "@cosmjs/encoding";
 import {
   Address,
-  PlatformName,
   UniversalAddress,
   registerNative,
 } from "@wormhole-foundation/connect-sdk";
@@ -104,7 +103,7 @@ function tryDecode(data: string): { data: Uint8Array; prefix?: string } {
 export class CosmwasmAddress implements Address {
   static readonly contractAddressByteSize = 32;
   static readonly accountAddressByteSize = 20;
-  public readonly platform: PlatformName = 'Cosmwasm';
+  public readonly platform = CosmwasmPlatform.platform;
 
   // the actual bytes of the address
   private readonly address: Uint8Array;
@@ -236,8 +235,7 @@ export class CosmwasmAddress implements Address {
   }
 
   static instanceof(address: any) {
-    const platform: PlatformName = 'Cosmwasm';
-    return address.platform === platform;
+    return address.platform === CosmwasmPlatform.platform;
   }
 
   equals(other: UniversalAddress): boolean {

--- a/platforms/cosmwasm/src/address.ts
+++ b/platforms/cosmwasm/src/address.ts
@@ -104,7 +104,7 @@ function tryDecode(data: string): { data: Uint8Array; prefix?: string } {
 export class CosmwasmAddress implements Address {
   static readonly contractAddressByteSize = 32;
   static readonly accountAddressByteSize = 20;
-  static readonly platform: PlatformName = 'Cosmwasm';
+  public readonly platform: PlatformName = 'Cosmwasm';
 
   // the actual bytes of the address
   private readonly address: Uint8Array;
@@ -236,7 +236,8 @@ export class CosmwasmAddress implements Address {
   }
 
   static instanceof(address: any) {
-    return address.platform === CosmwasmAddress.platform;
+    const platform: PlatformName = 'Cosmwasm';
+    return address.platform === platform;
   }
 
   equals(other: UniversalAddress): boolean {

--- a/platforms/cosmwasm/src/address.ts
+++ b/platforms/cosmwasm/src/address.ts
@@ -6,6 +6,7 @@ import {
 } from "@wormhole-foundation/connect-sdk";
 import { CosmwasmPlatform } from "./platform";
 import { nativeDenomToChain } from "./constants";
+import { AnyCosmwasmAddress } from "./types";
 
 declare global {
   namespace Wormhole {
@@ -113,7 +114,10 @@ export class CosmwasmAddress implements Address {
   // The denomType is "native", "ibc", or "factory"
   private readonly denomType?: string;
 
-  constructor(address: string | Uint8Array | UniversalAddress) {
+  constructor(address: AnyCosmwasmAddress) {
+    if (address instanceof CosmwasmAddress) {
+      Object.assign(this, address);
+    }
     if (typeof address === "string") {
       // A native denom like "uatom"
       if (nativeDenomToChain.has(CosmwasmPlatform.network, address)) {

--- a/platforms/cosmwasm/src/constants.ts
+++ b/platforms/cosmwasm/src/constants.ts
@@ -70,7 +70,7 @@ export const cosmwasmNetworkChainToChainId = constMap(
   networkChainCosmwasmChainIds,
 );
 
-export const cosmwasmAddressPrefix = [
+const cosmwasmAddressPrefix = [
   ["Cosmoshub", "cosmos"],
   ["Evmos", "evmos"],
   ["Injective", "inj"],
@@ -85,9 +85,6 @@ export const cosmwasmAddressPrefix = [
 
 export const chainToAddressPrefix = constMap(cosmwasmAddressPrefix);
 export const addressPrefixToChain = constMap(cosmwasmAddressPrefix, [1, [0]]);
-
-export const AllPrefixes = cosmwasmAddressPrefix.map(p => p[1]);
-export type AnyPrefix = typeof AllPrefixes[number];
 
 const cosmwasmNativeDenom = [
   [

--- a/platforms/cosmwasm/src/constants.ts
+++ b/platforms/cosmwasm/src/constants.ts
@@ -70,7 +70,7 @@ export const cosmwasmNetworkChainToChainId = constMap(
   networkChainCosmwasmChainIds,
 );
 
-const cosmwasmAddressPrefix = [
+export const cosmwasmAddressPrefix = [
   ["Cosmoshub", "cosmos"],
   ["Evmos", "evmos"],
   ["Injective", "inj"],
@@ -85,6 +85,9 @@ const cosmwasmAddressPrefix = [
 
 export const chainToAddressPrefix = constMap(cosmwasmAddressPrefix);
 export const addressPrefixToChain = constMap(cosmwasmAddressPrefix, [1, [0]]);
+
+export const AllPrefixes = cosmwasmAddressPrefix.map(p => p[1]);
+export type AnyPrefix = typeof AllPrefixes[number];
 
 const cosmwasmNativeDenom = [
   [

--- a/platforms/cosmwasm/src/platform.ts
+++ b/platforms/cosmwasm/src/platform.ts
@@ -1,5 +1,11 @@
 import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
-import { BankExtension, IbcExtension, QueryClient, setupBankExtension, setupIbcExtension } from "@cosmjs/stargate";
+import {
+  BankExtension,
+  IbcExtension,
+  QueryClient,
+  setupBankExtension,
+  setupIbcExtension,
+} from "@cosmjs/stargate";
 import { TendermintClient } from "@cosmjs/tendermint-rpc";
 
 import {
@@ -115,7 +121,11 @@ export module CosmwasmPlatform {
   ): QueryClient & BankExtension & IbcExtension => {
     // @ts-ignore
     const tmClient: TendermintClient = rpc.getTmClient()!;
-    return QueryClient.withExtensions(tmClient, setupBankExtension, setupIbcExtension);
+    return QueryClient.withExtensions(
+      tmClient,
+      setupBankExtension,
+      setupIbcExtension,
+    );
   };
 
   // cached channels from config if available

--- a/platforms/cosmwasm/src/platform.ts
+++ b/platforms/cosmwasm/src/platform.ts
@@ -1,5 +1,5 @@
 import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
-import { IbcExtension, QueryClient, setupIbcExtension } from "@cosmjs/stargate";
+import { BankExtension, IbcExtension, QueryClient, setupBankExtension, setupIbcExtension } from "@cosmjs/stargate";
 import { TendermintClient } from "@cosmjs/tendermint-rpc";
 
 import {
@@ -49,6 +49,7 @@ export module CosmwasmPlatform {
     isSupportedChain,
     getDecimals,
     getBalance,
+    getBalances,
     sendWait,
     getCurrentBlock,
     chainFromRpc,
@@ -111,10 +112,10 @@ export module CosmwasmPlatform {
 
   export const getQueryClient = (
     rpc: CosmWasmClient,
-  ): QueryClient & IbcExtension => {
+  ): QueryClient & BankExtension & IbcExtension => {
     // @ts-ignore
     const tmClient: TendermintClient = rpc.getTmClient()!;
-    return QueryClient.withExtensions(tmClient, setupIbcExtension);
+    return QueryClient.withExtensions(tmClient, setupBankExtension, setupIbcExtension);
   };
 
   // cached channels from config if available

--- a/platforms/cosmwasm/src/platformUtils.ts
+++ b/platforms/cosmwasm/src/platformUtils.ts
@@ -19,7 +19,7 @@ import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { CosmwasmPlatform } from "./platform";
 import { CosmwasmAddress } from "./address";
 import { BankExtension, IbcExtension, QueryClient, setupIbcExtension } from "@cosmjs/stargate";
-import { AnyCosmwasmAddress, toCosmwasmAddrString } from "./types";
+import { AnyCosmwasmAddress } from "./types";
 
 // forces CosmwasmUtils to implement PlatformUtils
 var _: PlatformUtils<"Cosmwasm"> = CosmwasmUtils;
@@ -59,7 +59,8 @@ export module CosmwasmUtils {
   ): Promise<bigint> {
     if (token === "native") return nativeDecimals(CosmwasmPlatform.platform);
 
-    const { decimals } = await rpc.queryContractSmart(toCosmwasmAddrString(token), {
+    const addrStr = new CosmwasmAddress(token).toString();
+    const { decimals } = await rpc.queryContractSmart(addrStr, {
       token_info: {},
     });
     return decimals;
@@ -79,7 +80,8 @@ export module CosmwasmUtils {
       return BigInt(amount);
     }
 
-    const { amount } = await rpc.getBalance(walletAddress, toCosmwasmAddrString(token));
+    const addrStr = new CosmwasmAddress(token).toString();
+    const { amount } = await rpc.getBalance(walletAddress, addrStr);
     return BigInt(amount);
   }
 
@@ -90,8 +92,8 @@ export module CosmwasmUtils {
     tokens: (AnyCosmwasmAddress | "native")[],
   ): Promise<Balances> {
     const allBalances = await rpc.bank.allBalances(walletAddress);
-    const balancesArr = tokens.map((t) => {
-      const address = t === 'native' ? getNativeDenom(chain) : toCosmwasmAddrString(t);
+    const balancesArr = tokens.map((token) => {
+      const address = token === 'native' ? getNativeDenom(chain) : new CosmwasmAddress(token).toString();
       const balance = allBalances.find(
         (balance) => balance.denom === address,
       );

--- a/platforms/cosmwasm/src/platformUtils.ts
+++ b/platforms/cosmwasm/src/platformUtils.ts
@@ -18,7 +18,12 @@ import {
 import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { CosmwasmPlatform } from "./platform";
 import { CosmwasmAddress } from "./address";
-import { BankExtension, IbcExtension, QueryClient, setupIbcExtension } from "@cosmjs/stargate";
+import {
+  BankExtension,
+  IbcExtension,
+  QueryClient,
+  setupIbcExtension,
+} from "@cosmjs/stargate";
 import { AnyCosmwasmAddress } from "./types";
 
 // forces CosmwasmUtils to implement PlatformUtils
@@ -93,18 +98,16 @@ export module CosmwasmUtils {
   ): Promise<Balances> {
     const allBalances = await rpc.bank.allBalances(walletAddress);
     const balancesArr = tokens.map((token) => {
-      const address = token === 'native' ? getNativeDenom(chain) : new CosmwasmAddress(token).toString();
-      const balance = allBalances.find(
-        (balance) => balance.denom === address,
-      );
+      const address =
+        token === "native"
+          ? getNativeDenom(chain)
+          : new CosmwasmAddress(token).toString();
+      const balance = allBalances.find((balance) => balance.denom === address);
       const balanceBigInt = balance ? BigInt(balance.amount) : null;
-      return { [address]: balanceBigInt }
+      return { [address]: balanceBigInt };
     });
 
-    return balancesArr.reduce(
-      (obj, item) => Object.assign(obj, item),
-      {}
-    );
+    return balancesArr.reduce((obj, item) => Object.assign(obj, item), {});
   }
 
   function getNativeDenom(chain: ChainName): string {

--- a/platforms/cosmwasm/src/protocols/ibc.ts
+++ b/platforms/cosmwasm/src/protocols/ibc.ts
@@ -38,12 +38,13 @@ import { CosmwasmContracts } from "../contracts";
 import { Gateway } from "../gateway";
 import { CosmwasmPlatform } from "../platform";
 import { CosmwasmUtils } from "../platformUtils";
-import { CosmwasmChainName, UniversalOrCosmwasm } from "../types";
+import { CosmwasmChainName, AnyCosmwasmAddress } from "../types";
 import {
   CosmwasmTransaction,
   CosmwasmUnsignedTransaction,
   computeFee,
 } from "../unsignedTransaction";
+import { CosmwasmAddress } from "../address";
 
 const millisToNano = (seconds: number) => seconds * 1_000_000;
 
@@ -87,12 +88,12 @@ export class CosmwasmIbcBridge implements IbcBridge<"Cosmwasm"> {
   }
 
   async *transfer(
-    sender: UniversalOrCosmwasm,
+    sender: AnyCosmwasmAddress,
     recipient: ChainAddress,
-    token: UniversalOrCosmwasm | "native",
+    token: AnyCosmwasmAddress | "native",
     amount: bigint,
   ): AsyncGenerator<CosmwasmUnsignedTransaction> {
-    const senderAddress = sender.toString();
+    const senderAddress = new CosmwasmAddress(sender).toString();
     const nonce = Math.round(Math.random() * 10000);
 
     // TODO: needs heavy testing
@@ -124,7 +125,7 @@ export class CosmwasmIbcBridge implements IbcBridge<"Cosmwasm"> {
     const timeout = millisToNano(Date.now() + IBC_TIMEOUT_MILLIS);
     const memo = JSON.stringify(payload);
 
-    const ibcDenom = Gateway.deriveIbcDenom(this.chain, token.toString());
+    const ibcDenom = token === 'native' ? CosmwasmPlatform.getNativeDenom(this.chain) : Gateway.deriveIbcDenom(this.chain, new CosmwasmAddress(token).toString());
     const ibcToken = coin(amount.toString(), ibcDenom.toString());
 
     const ibcMessage: MsgTransferEncodeObject = {

--- a/platforms/cosmwasm/src/protocols/ibc.ts
+++ b/platforms/cosmwasm/src/protocols/ibc.ts
@@ -125,7 +125,13 @@ export class CosmwasmIbcBridge implements IbcBridge<"Cosmwasm"> {
     const timeout = millisToNano(Date.now() + IBC_TIMEOUT_MILLIS);
     const memo = JSON.stringify(payload);
 
-    const ibcDenom = token === 'native' ? CosmwasmPlatform.getNativeDenom(this.chain) : Gateway.deriveIbcDenom(this.chain, new CosmwasmAddress(token).toString());
+    const ibcDenom =
+      token === "native"
+        ? CosmwasmPlatform.getNativeDenom(this.chain)
+        : Gateway.deriveIbcDenom(
+            this.chain,
+            new CosmwasmAddress(token).toString(),
+          );
     const ibcToken = coin(amount.toString(), ibcDenom.toString());
 
     const ibcMessage: MsgTransferEncodeObject = {

--- a/platforms/cosmwasm/src/protocols/ibc.ts
+++ b/platforms/cosmwasm/src/protocols/ibc.ts
@@ -37,7 +37,6 @@ import {
 import { CosmwasmContracts } from "../contracts";
 import { Gateway } from "../gateway";
 import { CosmwasmPlatform } from "../platform";
-import { CosmwasmUtils } from "../platformUtils";
 import { CosmwasmChainName, AnyCosmwasmAddress } from "../types";
 import {
   CosmwasmTransaction,
@@ -339,7 +338,7 @@ export class CosmwasmIbcBridge implements IbcBridge<"Cosmwasm"> {
     for (const xfer of xfers) {
       // If its present in the commitment results, its interpreted as in-flight
       // the client throws an error and we report any error as not in-flight
-      const qc = CosmwasmUtils.asQueryClient(this.rpc);
+      const qc = CosmwasmPlatform.getQueryClient(this.rpc);
       try {
         await qc.ibc.channel.packetCommitment(
           IBC_TRANSFER_PORT,

--- a/platforms/cosmwasm/src/types.ts
+++ b/platforms/cosmwasm/src/types.ts
@@ -7,13 +7,14 @@ import {
 import { logs as cosmosLogs } from "@cosmjs/stargate";
 
 export type CosmwasmChainName = PlatformToChains<"Cosmwasm">;
-export type UniversalOrCosmwasm = UniversalOrNative<"Cosmwasm"> | string;
+export type UniversalOrCosmwasm = UniversalOrNative<"Cosmwasm">;
+export type AnyCosmwasmAddress = UniversalOrCosmwasm | string;
 
 export interface WrappedRegistryResponse {
   address: string;
 }
 
-export const toCosmwasmAddrString = (addr: UniversalOrCosmwasm) =>
+export const toCosmwasmAddrString = (addr: AnyCosmwasmAddress) =>
   typeof addr === "string"
     ? addr
     : (addr instanceof UniversalAddress

--- a/platforms/cosmwasm/src/types.ts
+++ b/platforms/cosmwasm/src/types.ts
@@ -1,8 +1,6 @@
 import {
-  UniversalAddress,
   UniversalOrNative,
   PlatformToChains,
-  GatewayTransferMsg,
 } from "@wormhole-foundation/connect-sdk";
 import { logs as cosmosLogs } from "@cosmjs/stargate";
 

--- a/platforms/cosmwasm/src/types.ts
+++ b/platforms/cosmwasm/src/types.ts
@@ -8,19 +8,11 @@ import { logs as cosmosLogs } from "@cosmjs/stargate";
 
 export type CosmwasmChainName = PlatformToChains<"Cosmwasm">;
 export type UniversalOrCosmwasm = UniversalOrNative<"Cosmwasm">;
-export type AnyCosmwasmAddress = UniversalOrCosmwasm | string;
+export type AnyCosmwasmAddress = UniversalOrCosmwasm | string | Uint8Array;
 
 export interface WrappedRegistryResponse {
   address: string;
 }
-
-export const toCosmwasmAddrString = (addr: AnyCosmwasmAddress) =>
-  typeof addr === "string"
-    ? addr
-    : (addr instanceof UniversalAddress
-        ? addr.toNative("Cosmwasm")
-        : addr
-      ).unwrap();
 
 // TODO: do >1 key at a time
 export const searchCosmosLogs = (

--- a/platforms/evm/src/address.ts
+++ b/platforms/evm/src/address.ts
@@ -1,4 +1,4 @@
-import { Address, UniversalAddress } from '@wormhole-foundation/connect-sdk';
+import { Address, UniversalAddress, registerNative } from '@wormhole-foundation/connect-sdk';
 
 import { ethers } from 'ethers';
 import { AnyEvmAddress } from './types';
@@ -86,3 +86,5 @@ export class EvmAddress implements Address {
     return other.equals(this.toUniversalAddress());
   }
 }
+
+registerNative('Evm', EvmAddress);

--- a/platforms/evm/src/address.ts
+++ b/platforms/evm/src/address.ts
@@ -16,7 +16,7 @@ export const EvmZeroAddress = ethers.ZeroAddress;
 export class EvmAddress implements Address {
   static readonly byteSize = 20;
 
-  //stored as checksum address
+  // stored as checksum address
   private readonly address: string;
 
   constructor(address: string | Uint8Array | UniversalAddress) {

--- a/platforms/evm/src/address.ts
+++ b/platforms/evm/src/address.ts
@@ -1,6 +1,7 @@
 import { Address, UniversalAddress } from '@wormhole-foundation/connect-sdk';
 
 import { ethers } from 'ethers';
+import { AnyEvmAddress } from './types';
 
 declare global {
   namespace Wormhole {
@@ -19,7 +20,10 @@ export class EvmAddress implements Address {
   // stored as checksum address
   private readonly address: string;
 
-  constructor(address: string | Uint8Array | UniversalAddress) {
+  constructor(address: AnyEvmAddress) {
+    if (address instanceof EvmAddress) {
+      Object.assign(this, address);
+    }
     if (typeof address === 'string') {
       if (!EvmAddress.isValidAddress(address))
         throw new Error(

--- a/platforms/evm/src/address.ts
+++ b/platforms/evm/src/address.ts
@@ -1,4 +1,4 @@
-import { Address, UniversalAddress } from '@wormhole-foundation/connect-sdk';
+import { Address, PlatformName, UniversalAddress } from '@wormhole-foundation/connect-sdk';
 
 import { ethers } from 'ethers';
 import { AnyEvmAddress } from './types';
@@ -16,13 +16,16 @@ export const EvmZeroAddress = ethers.ZeroAddress;
 
 export class EvmAddress implements Address {
   static readonly byteSize = 20;
+  static readonly platform: PlatformName = 'Evm';
 
   // stored as checksum address
   private readonly address: string;
 
   constructor(address: AnyEvmAddress) {
-    if (address instanceof EvmAddress) {
-      Object.assign(this, address);
+    if (EvmAddress.instanceof(address)) {
+      const a = address as unknown as EvmAddress;
+      this.address = a.address;
+      return;
     }
     if (typeof address === 'string') {
       if (!EvmAddress.isValidAddress(address))
@@ -38,7 +41,7 @@ export class EvmAddress implements Address {
         );
 
       this.address = ethers.getAddress(ethers.hexlify(address));
-    } else if (address instanceof UniversalAddress) {
+    } else if (UniversalAddress.instanceof(address)) {
       // If its a universal address and we want it to be an ethereum address,
       // we need to chop off the first 12 bytes of padding
       const addressBytes = address.toUint8Array();
@@ -74,6 +77,9 @@ export class EvmAddress implements Address {
   }
   static isValidAddress(address: string) {
     return ethers.isAddress(address);
+  }
+  static instanceof(address: any) {
+    return address.platform === EvmAddress.platform;
   }
   equals(other: UniversalAddress): boolean {
     return other.equals(this.toUniversalAddress());

--- a/platforms/evm/src/address.ts
+++ b/platforms/evm/src/address.ts
@@ -1,7 +1,8 @@
-import { Address, PlatformName, UniversalAddress } from '@wormhole-foundation/connect-sdk';
+import { Address, UniversalAddress } from '@wormhole-foundation/connect-sdk';
 
 import { ethers } from 'ethers';
 import { AnyEvmAddress } from './types';
+import { EvmPlatform } from './platform';
 
 declare global {
   namespace Wormhole {
@@ -16,7 +17,7 @@ export const EvmZeroAddress = ethers.ZeroAddress;
 
 export class EvmAddress implements Address {
   static readonly byteSize = 20;
-  public readonly platform: PlatformName = 'Evm';
+  public readonly platform = EvmPlatform.platform;
 
   // stored as checksum address
   private readonly address: string;
@@ -79,8 +80,7 @@ export class EvmAddress implements Address {
     return ethers.isAddress(address);
   }
   static instanceof(address: any) {
-    const platform: PlatformName = 'Evm'
-    return address.platform === platform;
+    return address.platform === EvmPlatform.platform;
   }
   equals(other: UniversalAddress): boolean {
     return other.equals(this.toUniversalAddress());

--- a/platforms/evm/src/address.ts
+++ b/platforms/evm/src/address.ts
@@ -16,7 +16,7 @@ export const EvmZeroAddress = ethers.ZeroAddress;
 
 export class EvmAddress implements Address {
   static readonly byteSize = 20;
-  static readonly platform: PlatformName = 'Evm';
+  public readonly platform: PlatformName = 'Evm';
 
   // stored as checksum address
   private readonly address: string;
@@ -79,7 +79,8 @@ export class EvmAddress implements Address {
     return ethers.isAddress(address);
   }
   static instanceof(address: any) {
-    return address.platform === EvmAddress.platform;
+    const platform: PlatformName = 'Evm'
+    return address.platform === platform;
   }
   equals(other: UniversalAddress): boolean {
     return other.equals(this.toUniversalAddress());

--- a/platforms/evm/src/index.ts
+++ b/platforms/evm/src/index.ts
@@ -3,6 +3,7 @@ export * from './address';
 export * from './contracts';
 export * from './unsignedTransaction';
 export * from './platform';
+export * from './types';
 export * from './chain';
 
 export * from './protocols/tokenBridge';
@@ -10,4 +11,3 @@ export * from './protocols/automaticTokenBridge';
 export * from './protocols/circleBridge';
 export * from './protocols/automaticCircleBridge';
 
-export * from './types';

--- a/platforms/evm/src/platform.ts
+++ b/platforms/evm/src/platform.ts
@@ -44,6 +44,7 @@ export module EvmPlatform {
     isSupportedChain,
     getDecimals,
     getBalance,
+    getBalances,
     sendWait,
     getCurrentBlock,
     chainFromRpc,

--- a/platforms/evm/src/platformUtils.ts
+++ b/platforms/evm/src/platformUtils.ts
@@ -81,15 +81,15 @@ export module EvmUtils {
     walletAddr: string,
     tokens: (AnyEvmAddress | 'native')[],
   ): Promise<Balances> {
-    const balancesArr = await Promise.all(tokens.map(async (token) => {
-      const balance = await getBalance(chain, rpc, walletAddr, token);
-      const address = token === 'native' ? 'native' : new EvmAddress(token).toString();
-      return { [address]: balance }
-    }))
-    return balancesArr.reduce(
-      (obj, item) => Object.assign(obj, item),
-      {}
+    const balancesArr = await Promise.all(
+      tokens.map(async (token) => {
+        const balance = await getBalance(chain, rpc, walletAddr, token);
+        const address =
+          token === 'native' ? 'native' : new EvmAddress(token).toString();
+        return { [address]: balance };
+      }),
     );
+    return balancesArr.reduce((obj, item) => Object.assign(obj, item), {});
   }
 
   export async function sendWait(

--- a/platforms/evm/src/platformUtils.ts
+++ b/platforms/evm/src/platformUtils.ts
@@ -16,7 +16,7 @@ import { evmChainIdToNetworkChainPair } from './constants';
 import { EvmAddress, EvmZeroAddress } from './address';
 import { EvmContracts } from './contracts';
 import { EvmPlatform } from './platform';
-import { AnyEvmAddress, toEvmAddrString } from './types';
+import { AnyEvmAddress } from './types';
 
 // forces EvmUtils to implement PlatformUtils
 var _: PlatformUtils<'Evm'> = EvmUtils;
@@ -55,7 +55,7 @@ export module EvmUtils {
 
     const tokenContract = EvmContracts.getTokenImplementation(
       rpc,
-      toEvmAddrString(token),
+      new EvmAddress(token).toString(),
     );
     return tokenContract.decimals();
   }
@@ -70,7 +70,7 @@ export module EvmUtils {
 
     const tokenImpl = EvmContracts.getTokenImplementation(
       rpc,
-      toEvmAddrString(token),
+      new EvmAddress(token).toString(),
     );
     return tokenImpl.balanceOf(walletAddr);
   }
@@ -81,9 +81,9 @@ export module EvmUtils {
     walletAddr: string,
     tokens: (AnyEvmAddress | 'native')[],
   ): Promise<Balances> {
-    const balancesArr = await Promise.all(tokens.map(async (a) => {
-      const balance = await getBalance(chain, rpc, walletAddr, a);
-      const address = toEvmAddrString(a);
+    const balancesArr = await Promise.all(tokens.map(async (token) => {
+      const balance = await getBalance(chain, rpc, walletAddr, token);
+      const address = token === 'native' ? 'native' : new EvmAddress(token).toString();
       return { [address]: balance }
     }))
     return balancesArr.reduce(

--- a/platforms/evm/src/platformUtils.ts
+++ b/platforms/evm/src/platformUtils.ts
@@ -8,7 +8,7 @@ import {
   nativeDecimals,
   chainToPlatform,
   PlatformUtils,
-  UniversalOrNative,
+  Balances,
 } from '@wormhole-foundation/connect-sdk';
 
 import { Provider } from 'ethers';
@@ -16,6 +16,7 @@ import { evmChainIdToNetworkChainPair } from './constants';
 import { EvmAddress, EvmZeroAddress } from './address';
 import { EvmContracts } from './contracts';
 import { EvmPlatform } from './platform';
+import { AnyEvmAddress, toEvmAddrString } from './types';
 
 // forces EvmUtils to implement PlatformUtils
 var _: PlatformUtils<'Evm'> = EvmUtils;
@@ -48,32 +49,47 @@ export module EvmUtils {
   export async function getDecimals(
     chain: ChainName,
     rpc: Provider,
-    token: UniversalOrNative<'Evm'> | 'native',
+    token: AnyEvmAddress | 'native',
   ): Promise<bigint> {
     if (token === 'native') return nativeDecimals(EvmPlatform.platform);
 
     const tokenContract = EvmContracts.getTokenImplementation(
       rpc,
-      token.toString(),
+      toEvmAddrString(token),
     );
-    const decimals = await tokenContract.decimals();
-    return decimals;
+    return tokenContract.decimals();
   }
 
   export async function getBalance(
     chain: ChainName,
     rpc: Provider,
     walletAddr: string,
-    token: UniversalOrNative<'Evm'> | 'native',
+    token: AnyEvmAddress | 'native',
   ): Promise<bigint | null> {
-    if (token === 'native') return await rpc.getBalance(walletAddr);
+    if (token === 'native') return rpc.getBalance(walletAddr);
 
     const tokenImpl = EvmContracts.getTokenImplementation(
       rpc,
-      token.toString(),
+      toEvmAddrString(token),
     );
-    const balance = await tokenImpl.balanceOf(walletAddr);
-    return balance;
+    return tokenImpl.balanceOf(walletAddr);
+  }
+
+  export async function getBalances(
+    chain: ChainName,
+    rpc: Provider,
+    walletAddr: string,
+    tokens: (AnyEvmAddress | 'native')[],
+  ): Promise<Balances> {
+    const balancesArr = await Promise.all(tokens.map(async (a) => {
+      const balance = await getBalance(chain, rpc, walletAddr, a);
+      const address = toEvmAddrString(a);
+      return { [address]: balance }
+    }))
+    return balancesArr.reduce(
+      (obj, item) => Object.assign(obj, item),
+      {}
+    );
   }
 
   export async function sendWait(

--- a/platforms/evm/src/protocols/automaticCircleBridge.ts
+++ b/platforms/evm/src/protocols/automaticCircleBridge.ts
@@ -8,12 +8,7 @@ import {
 
 import { evmNetworkChainToEvmChainId } from '../constants';
 
-import {
-  AnyEvmAddress,
-  EvmChainName,
-  addChainId,
-  addFrom,
-} from '../types';
+import { AnyEvmAddress, EvmChainName, addChainId, addFrom } from '../types';
 import { EvmUnsignedTransaction } from '../unsignedTransaction';
 import { CircleRelayer } from '../ethers-contracts';
 import { Provider, TransactionRequest } from 'ethers';
@@ -65,7 +60,9 @@ export class EvmAutomaticCircleBridge implements AutomaticCircleBridge<'Evm'> {
       .toUint8Array();
     const nativeTokenGas = nativeGas ? nativeGas : 0n;
 
-    const tokenAddr = new EvmAddress(token.address.toUniversalAddress()).toString();
+    const tokenAddr = new EvmAddress(
+      token.address.toUniversalAddress(),
+    ).toString();
 
     const tokenContract = EvmContracts.getTokenImplementation(
       this.provider,

--- a/platforms/evm/src/protocols/automaticCircleBridge.ts
+++ b/platforms/evm/src/protocols/automaticCircleBridge.ts
@@ -9,17 +9,17 @@ import {
 import { evmNetworkChainToEvmChainId } from '../constants';
 
 import {
+  AnyEvmAddress,
   EvmChainName,
-  UniversalOrEvm,
   addChainId,
   addFrom,
-  toEvmAddrString,
 } from '../types';
 import { EvmUnsignedTransaction } from '../unsignedTransaction';
 import { CircleRelayer } from '../ethers-contracts';
 import { Provider, TransactionRequest } from 'ethers';
 import { EvmContracts } from '../contracts';
 import { EvmPlatform } from '../platform';
+import { EvmAddress } from '../address';
 
 export class EvmAutomaticCircleBridge implements AutomaticCircleBridge<'Evm'> {
   readonly circleRelayer: CircleRelayer;
@@ -53,19 +53,19 @@ export class EvmAutomaticCircleBridge implements AutomaticCircleBridge<'Evm'> {
 
   async *transfer(
     token: TokenId,
-    sender: UniversalOrEvm,
+    sender: AnyEvmAddress,
     recipient: ChainAddress,
     amount: bigint,
     nativeGas?: bigint,
   ): AsyncGenerator<EvmUnsignedTransaction> {
-    const senderAddr = toEvmAddrString(sender);
+    const senderAddr = new EvmAddress(sender).toString();
     const recipientChainId = chainToChainId(recipient.chain);
     const recipientAddress = recipient.address
       .toUniversalAddress()
       .toUint8Array();
     const nativeTokenGas = nativeGas ? nativeGas : 0n;
 
-    const tokenAddr = toEvmAddrString(token.address.toUniversalAddress());
+    const tokenAddr = new EvmAddress(token.address.toUniversalAddress()).toString();
 
     const tokenContract = EvmContracts.getTokenImplementation(
       this.provider,

--- a/platforms/evm/src/protocols/automaticTokenBridge.ts
+++ b/platforms/evm/src/protocols/automaticTokenBridge.ts
@@ -12,12 +12,7 @@ import {
 import { Provider, TransactionRequest } from 'ethers';
 
 import { evmNetworkChainToEvmChainId } from '../constants';
-import {
-  AnyEvmAddress,
-  EvmChainName,
-  addChainId,
-  addFrom,
-} from '../types';
+import { AnyEvmAddress, EvmChainName, addChainId, addFrom } from '../types';
 import { EvmUnsignedTransaction } from '../unsignedTransaction';
 import { TokenBridgeRelayer } from '../ethers-contracts';
 import { EvmContracts } from '../contracts';
@@ -131,7 +126,9 @@ export class EvmAutomaticTokenBridge implements AutomaticTokenBridge<'Evm'> {
         : token;
 
     const destChainId = toChainId(recipient.chain);
-    const destTokenAddress = new EvmAddress(tokenId.address.toString()).toString();
+    const destTokenAddress = new EvmAddress(
+      tokenId.address.toString(),
+    ).toString();
 
     const tokenContract = EvmContracts.getTokenImplementation(
       this.provider,

--- a/platforms/evm/src/protocols/circleBridge.ts
+++ b/platforms/evm/src/protocols/circleBridge.ts
@@ -105,7 +105,9 @@ export class EvmCircleBridge implements CircleBridge<'Evm'> {
     const recipientAddress = recipient.address
       .toUniversalAddress()
       .toUint8Array();
-    const tokenAddr = new EvmAddress(token.address as UniversalOrEvm).toString();
+    const tokenAddr = new EvmAddress(
+      token.address as UniversalOrEvm,
+    ).toString();
 
     const tokenContract = EvmContracts.getTokenImplementation(
       this.provider,

--- a/platforms/evm/src/protocols/circleBridge.ts
+++ b/platforms/evm/src/protocols/circleBridge.ts
@@ -17,8 +17,8 @@ import { evmNetworkChainToEvmChainId } from '../constants';
 import {
   addFrom,
   addChainId,
-  toEvmAddrString,
   EvmChainName,
+  AnyEvmAddress,
   UniversalOrEvm,
 } from '../types';
 import { EvmUnsignedTransaction } from '../unsignedTransaction';
@@ -26,6 +26,7 @@ import { MessageTransmitter, TokenMessenger } from '../ethers-contracts';
 import { LogDescription, Provider, TransactionRequest } from 'ethers';
 import { EvmContracts } from '../contracts';
 import { EvmPlatform } from '../platform';
+import { EvmAddress } from '../address';
 
 //https://github.com/circlefin/evm-cctp-contracts
 
@@ -77,11 +78,11 @@ export class EvmCircleBridge implements CircleBridge<'Evm'> {
   }
 
   async *redeem(
-    sender: UniversalOrEvm,
+    sender: AnyEvmAddress,
     message: string,
     attestation: string,
   ): AsyncGenerator<UnsignedTransaction> {
-    const senderAddr = toEvmAddrString(sender);
+    const senderAddr = new EvmAddress(sender).toString();
 
     const txReq = await this.msgTransmitter.receiveMessage.populateTransaction(
       hexByteStringToUint8Array(message),
@@ -96,15 +97,15 @@ export class EvmCircleBridge implements CircleBridge<'Evm'> {
   //alternative naming: initiateTransfer
   async *transfer(
     token: TokenId,
-    sender: UniversalOrEvm,
+    sender: AnyEvmAddress,
     recipient: ChainAddress,
     amount: bigint,
   ): AsyncGenerator<EvmUnsignedTransaction> {
-    const senderAddr = toEvmAddrString(sender);
+    const senderAddr = new EvmAddress(sender).toString();
     const recipientAddress = recipient.address
       .toUniversalAddress()
       .toUint8Array();
-    const tokenAddr = toEvmAddrString(token.address as UniversalOrEvm);
+    const tokenAddr = new EvmAddress(token.address as UniversalOrEvm).toString();
 
     const tokenContract = EvmContracts.getTokenImplementation(
       this.provider,

--- a/platforms/evm/src/protocols/tokenBridge.ts
+++ b/platforms/evm/src/protocols/tokenBridge.ts
@@ -67,7 +67,9 @@ export class EvmTokenBridge implements TokenBridge<'Evm'> {
   }
 
   async isWrappedAsset(token: AnyEvmAddress): Promise<boolean> {
-    return await this.tokenBridge.isWrappedAsset(new EvmAddress(token).toString());
+    return await this.tokenBridge.isWrappedAsset(
+      new EvmAddress(token).toString(),
+    );
   }
 
   async getOriginalAsset(token: AnyEvmAddress): Promise<TokenId> {

--- a/platforms/evm/src/protocols/wormholeCore.ts
+++ b/platforms/evm/src/protocols/wormholeCore.ts
@@ -9,13 +9,13 @@ import {
 import { EvmUnsignedTransaction } from '../unsignedTransaction';
 import { EvmContracts } from '../contracts';
 import {
+  AnyEvmAddress,
   EvmChainName,
-  UniversalOrEvm,
   addChainId,
   addFrom,
-  toEvmAddrString,
 } from '../types';
 import { EvmPlatform } from '../platform';
+import { EvmAddress } from '../address';
 
 export class EvmWormholeCore implements WormholeCore<'Evm'> {
   readonly chainId: bigint;
@@ -44,10 +44,10 @@ export class EvmWormholeCore implements WormholeCore<'Evm'> {
   }
 
   async *publishMessage(
-    sender: UniversalOrEvm,
+    sender: AnyEvmAddress,
     message: Uint8Array | string,
   ): AsyncGenerator<EvmUnsignedTransaction> {
-    const senderAddr = toEvmAddrString(sender);
+    const senderAddr = new EvmAddress(sender).toString();
 
     const txReq = await this.core.publishMessage.populateTransaction(
       0,

--- a/platforms/evm/src/protocols/wormholeCore.ts
+++ b/platforms/evm/src/protocols/wormholeCore.ts
@@ -8,12 +8,7 @@ import {
 } from '../constants';
 import { EvmUnsignedTransaction } from '../unsignedTransaction';
 import { EvmContracts } from '../contracts';
-import {
-  AnyEvmAddress,
-  EvmChainName,
-  addChainId,
-  addFrom,
-} from '../types';
+import { AnyEvmAddress, EvmChainName, addChainId, addFrom } from '../types';
 import { EvmPlatform } from '../platform';
 import { EvmAddress } from '../address';
 

--- a/platforms/evm/src/types.ts
+++ b/platforms/evm/src/types.ts
@@ -15,12 +15,7 @@ export const unusedArbiterFee = 0n;
 
 export type EvmChainName = PlatformToChains<'Evm'>;
 export type UniversalOrEvm = UniversalOrNative<'Evm'>;
-export type AnyEvmAddress = UniversalOrEvm | string;
-
-export const toEvmAddrString = (addr: AnyEvmAddress) =>
-  typeof addr === 'string'
-    ? addr
-    : (addr instanceof UniversalAddress ? addr.toNative('Evm') : addr).unwrap();
+export type AnyEvmAddress = UniversalOrEvm | string | Uint8Array;
 
 export const addFrom = (txReq: TransactionRequest, from: string) => ({
   ...txReq,

--- a/platforms/evm/src/types.ts
+++ b/platforms/evm/src/types.ts
@@ -1,13 +1,8 @@
 import {
   UniversalOrNative,
-  registerNative,
   PlatformToChains,
 } from '@wormhole-foundation/connect-sdk';
 import { TransactionRequest } from 'ethers';
-
-import { EvmAddress } from './address';
-
-registerNative('Evm', EvmAddress);
 
 export const unusedNonce = 0;
 export const unusedArbiterFee = 0n;

--- a/platforms/evm/src/types.ts
+++ b/platforms/evm/src/types.ts
@@ -14,9 +14,10 @@ export const unusedNonce = 0;
 export const unusedArbiterFee = 0n;
 
 export type EvmChainName = PlatformToChains<'Evm'>;
-export type UniversalOrEvm = UniversalOrNative<'Evm'> | string;
+export type UniversalOrEvm = UniversalOrNative<'Evm'>;
+export type AnyEvmAddress = UniversalOrEvm | string;
 
-export const toEvmAddrString = (addr: UniversalOrEvm) =>
+export const toEvmAddrString = (addr: AnyEvmAddress) =>
   typeof addr === 'string'
     ? addr
     : (addr instanceof UniversalAddress ? addr.toNative('Evm') : addr).unwrap();

--- a/platforms/evm/src/types.ts
+++ b/platforms/evm/src/types.ts
@@ -1,5 +1,4 @@
 import {
-  UniversalAddress,
   UniversalOrNative,
   registerNative,
   PlatformToChains,

--- a/platforms/solana/__tests__/unit/platform.test.ts
+++ b/platforms/solana/__tests__/unit/platform.test.ts
@@ -12,8 +12,6 @@ import {
 
 import { SolanaPlatform } from '../../src';
 
-import { PublicKey } from '@solana/web3.js';
-
 // @ts-ignore -- this is the mock we import above
 import { getDefaultProvider } from '@solana/web3.js';
 

--- a/platforms/solana/src/address.ts
+++ b/platforms/solana/src/address.ts
@@ -8,6 +8,7 @@ import {
 
 import { PublicKey } from '@solana/web3.js';
 import { AnySolanaAddress } from './types';
+import { SolanaPlatform } from '../dist/esm';
 
 declare global {
   namespace Wormhole {
@@ -23,7 +24,7 @@ export const SolanaZeroAddress = '11111111111111111111111111111111';
 
 export class SolanaAddress implements Address {
   static readonly byteSize = 32;
-  public readonly platform: PlatformName = 'Solana';
+  public readonly platform: PlatformName = SolanaPlatform.platform;
 
   private readonly address: PublicKey;
 
@@ -34,7 +35,9 @@ export class SolanaAddress implements Address {
       return;
     }
     if (UniversalAddress.instanceof(address))
-      this.address = new PublicKey((address as UniversalAddress).toUint8Array());
+      this.address = new PublicKey(
+        (address as UniversalAddress).toUint8Array(),
+      );
     if (typeof address === 'string' && isHexByteString(address))
       this.address = new PublicKey(hexByteStringToUint8Array(address));
     else this.address = new PublicKey(address);
@@ -57,8 +60,7 @@ export class SolanaAddress implements Address {
   }
 
   static instanceof(address: any) {
-    const platform: PlatformName = 'Solana';
-    return address.platform === platform;
+    return address.platform === SolanaPlatform.platform;
   }
 
   equals(other: UniversalAddress): boolean {

--- a/platforms/solana/src/address.ts
+++ b/platforms/solana/src/address.ts
@@ -4,6 +4,7 @@ import {
   Address,
   UniversalAddress,
   PlatformName,
+  registerNative,
 } from '@wormhole-foundation/connect-sdk';
 
 import { PublicKey } from '@solana/web3.js';
@@ -67,3 +68,5 @@ export class SolanaAddress implements Address {
     return this.toUniversalAddress().equals(other);
   }
 }
+
+registerNative('Solana', SolanaAddress);

--- a/platforms/solana/src/address.ts
+++ b/platforms/solana/src/address.ts
@@ -23,7 +23,7 @@ export const SolanaZeroAddress = '11111111111111111111111111111111';
 
 export class SolanaAddress implements Address {
   static readonly byteSize = 32;
-  static readonly platform: PlatformName = 'Solana';
+  public readonly platform: PlatformName = 'Solana';
 
   private readonly address: PublicKey;
 
@@ -57,7 +57,8 @@ export class SolanaAddress implements Address {
   }
 
   static instanceof(address: any) {
-    return address.platform === SolanaAddress.platform;
+    const platform: PlatformName = 'Solana';
+    return address.platform === platform;
   }
 
   equals(other: UniversalAddress): boolean {

--- a/platforms/solana/src/address.ts
+++ b/platforms/solana/src/address.ts
@@ -5,7 +5,8 @@ import {
   UniversalAddress,
 } from '@wormhole-foundation/connect-sdk';
 
-import { PublicKey, PublicKeyInitData } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
+import { AnySolanaAddress } from './types';
 
 declare global {
   namespace Wormhole {
@@ -24,7 +25,10 @@ export class SolanaAddress implements Address {
 
   private readonly address: PublicKey;
 
-  constructor(address: PublicKeyInitData | UniversalAddress) {
+  constructor(address: AnySolanaAddress) {
+    if (address instanceof SolanaAddress) {
+      Object.assign(this, address);
+    }
     if (address instanceof UniversalAddress)
       this.address = new PublicKey(address.toUint8Array());
     if (typeof address === 'string' && isHexByteString(address))

--- a/platforms/solana/src/address.ts
+++ b/platforms/solana/src/address.ts
@@ -3,6 +3,7 @@ import {
   hexByteStringToUint8Array,
   Address,
   UniversalAddress,
+  PlatformName,
 } from '@wormhole-foundation/connect-sdk';
 
 import { PublicKey } from '@solana/web3.js';
@@ -22,15 +23,18 @@ export const SolanaZeroAddress = '11111111111111111111111111111111';
 
 export class SolanaAddress implements Address {
   static readonly byteSize = 32;
+  static readonly platform: PlatformName = 'Solana';
 
   private readonly address: PublicKey;
 
   constructor(address: AnySolanaAddress) {
-    if (address instanceof SolanaAddress) {
-      Object.assign(this, address);
+    if (SolanaAddress.instanceof(address)) {
+      const a = address as unknown as SolanaAddress;
+      this.address = a.address;
+      return;
     }
-    if (address instanceof UniversalAddress)
-      this.address = new PublicKey(address.toUint8Array());
+    if (UniversalAddress.instanceof(address))
+      this.address = new PublicKey((address as UniversalAddress).toUint8Array());
     if (typeof address === 'string' && isHexByteString(address))
       this.address = new PublicKey(hexByteStringToUint8Array(address));
     else this.address = new PublicKey(address);
@@ -50,6 +54,10 @@ export class SolanaAddress implements Address {
   }
   toUniversalAddress() {
     return new UniversalAddress(this.address.toBytes());
+  }
+
+  static instanceof(address: any) {
+    return address.platform === SolanaAddress.platform;
   }
 
   equals(other: UniversalAddress): boolean {

--- a/platforms/solana/src/address.ts
+++ b/platforms/solana/src/address.ts
@@ -8,7 +8,7 @@ import {
 
 import { PublicKey } from '@solana/web3.js';
 import { AnySolanaAddress } from './types';
-import { SolanaPlatform } from '../dist/esm';
+import { SolanaPlatform } from './platform';
 
 declare global {
   namespace Wormhole {

--- a/platforms/solana/src/chain.ts
+++ b/platforms/solana/src/chain.ts
@@ -3,27 +3,26 @@ import {
   ChainContext,
   NativeAddress,
   UniversalAddress,
+  UniversalOrNative,
   toNative,
 } from '@wormhole-foundation/connect-sdk';
 import { getAssociatedTokenAddress } from '@solana/spl-token';
 import { SolanaPlatform } from './platform';
-import { AnySolanaAddress } from './types';
-import { SolanaAddress } from './address';
 
 export class SolanaChain extends ChainContext<'Solana'> {
   // @ts-ignore
   readonly platform = SolanaPlatform;
 
   async getTokenAccount(
-    token: AnySolanaAddress | 'native',
+    token: UniversalOrNative<'Solana'> | 'native',
     address: UniversalAddress,
   ): Promise<NativeAddress<'Solana'>> {
     const tb = await this.getTokenBridge();
 
-    const mintAddress =
+    const mintAddress: UniversalOrNative<'Solana'> =
       token === 'native'
         ? await tb.getWrappedNative()
-        : new SolanaAddress(token);
+        : token.toUniversalAddress();
 
     const mint = new PublicKey(mintAddress.toUint8Array());
     const owner = new PublicKey(address.toUint8Array());

--- a/platforms/solana/src/chain.ts
+++ b/platforms/solana/src/chain.ts
@@ -3,27 +3,27 @@ import {
   ChainContext,
   NativeAddress,
   UniversalAddress,
-  UniversalOrNative,
-  Platform,
   toNative,
 } from '@wormhole-foundation/connect-sdk';
 import { getAssociatedTokenAddress } from '@solana/spl-token';
 import { SolanaPlatform } from './platform';
+import { AnySolanaAddress } from './types';
+import { SolanaAddress } from './address';
 
 export class SolanaChain extends ChainContext<'Solana'> {
   // @ts-ignore
   readonly platform = SolanaPlatform;
 
   async getTokenAccount(
-    token: UniversalOrNative<'Solana'> | 'native',
+    token: AnySolanaAddress | 'native',
     address: UniversalAddress,
   ): Promise<NativeAddress<'Solana'>> {
     const tb = await this.getTokenBridge();
 
-    const mintAddress: UniversalOrNative<'Solana'> =
+    const mintAddress =
       token === 'native'
         ? await tb.getWrappedNative()
-        : token.toUniversalAddress();
+        : new SolanaAddress(token);
 
     const mint = new PublicKey(mintAddress.toUint8Array());
     const owner = new PublicKey(address.toUint8Array());

--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -37,6 +37,7 @@ export module SolanaPlatform {
     isSupportedChain,
     getDecimals,
     getBalance,
+    getBalances,
     sendWait,
     getCurrentBlock,
     chainFromRpc,

--- a/platforms/solana/src/platformUtils.ts
+++ b/platforms/solana/src/platformUtils.ts
@@ -98,13 +98,12 @@ export module SolanaUtils {
       native = BigInt(await rpc.getBalance(new PublicKey(walletAddress)));
     }
 
-    const splParsedTokenAccounts =
-      await rpc.getParsedTokenAccountsByOwner(
-        new PublicKey(walletAddress),
-        {
-          programId: new PublicKey(TOKEN_PROGRAM_ID),
-        },
-      );
+    const splParsedTokenAccounts = await rpc.getParsedTokenAccountsByOwner(
+      new PublicKey(walletAddress),
+      {
+        programId: new PublicKey(TOKEN_PROGRAM_ID),
+      },
+    );
 
     const balancesArr = tokens.map((token) => {
       if (token === 'native') {
@@ -118,10 +117,7 @@ export module SolanaUtils {
       return { [addrString]: BigInt(amount) };
     });
 
-    return balancesArr.reduce(
-      (obj, item) => Object.assign(obj, item),
-      {}
-    );
+    return balancesArr.reduce((obj, item) => Object.assign(obj, item), {});
   }
 
   export async function sendWait(

--- a/platforms/solana/src/platformUtils.ts
+++ b/platforms/solana/src/platformUtils.ts
@@ -10,11 +10,14 @@ import {
   PlatformUtils,
   chainToPlatform,
   UniversalOrNative,
+  Balances,
 } from '@wormhole-foundation/connect-sdk';
 import { Connection, ParsedAccountData, PublicKey } from '@solana/web3.js';
 import { solGenesisHashToNetworkChainPair } from './constants';
 import { SolanaPlatform } from './platform';
 import { SolanaAddress, SolanaZeroAddress } from './address';
+import { AnySolanaAddress, toSolanaAddrPublicKey, toSolanaAddrString } from './types';
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
 
 // forces SolanaUtils to implement PlatformUtils
 var _: PlatformUtils<'Solana'> = SolanaUtils;
@@ -64,7 +67,7 @@ export module SolanaUtils {
     chain: ChainName,
     rpc: Connection,
     walletAddress: string,
-    token: UniversalOrNative<'Solana'> | 'native',
+    token: AnySolanaAddress | 'native',
   ): Promise<bigint | null> {
     if (token === 'native')
       return BigInt(await rpc.getBalance(new PublicKey(walletAddress)));
@@ -76,12 +79,49 @@ export module SolanaUtils {
 
     const splToken = await rpc.getTokenAccountsByOwner(
       new PublicKey(walletAddress),
-      { mint: new PublicKey(token.toUint8Array()) },
+      { mint: toSolanaAddrPublicKey(token) },
     );
     if (!splToken.value[0]) return null;
 
     const balance = await rpc.getTokenAccountBalance(splToken.value[0].pubkey);
     return BigInt(balance.value.amount);
+  }
+
+  export async function getBalances(
+    chain: ChainName,
+    rpc: Connection,
+    walletAddress: string,
+    tokens: (AnySolanaAddress | 'native')[],
+  ): Promise<Balances> {
+    let native: bigint;
+    if (tokens.includes('native')) {
+      native = BigInt(await rpc.getBalance(new PublicKey(walletAddress)));
+    }
+
+    const splParsedTokenAccounts =
+      await rpc.getParsedTokenAccountsByOwner(
+        new PublicKey(walletAddress),
+        {
+          programId: new PublicKey(TOKEN_PROGRAM_ID),
+        },
+      );
+
+    const balancesArr = tokens.map((address) => {
+      if (address === 'native') {
+        return { ['native']: native };
+      }
+      const addrString = toSolanaAddrString(address);
+      const amount = splParsedTokenAccounts.value.find(
+        (v) => v?.account.data.parsed?.info?.mint === address,
+      )?.account.data.parsed?.info?.tokenAmount?.amount;
+      if (!amount) return { [addrString]: null };
+      return { [addrString]: BigInt(amount) };
+    });
+
+    return balancesArr.reduce(
+      (obj, item) => Object.assign(obj, item),
+      {}
+    );
   }
 
   export async function sendWait(

--- a/platforms/solana/src/platformUtils.ts
+++ b/platforms/solana/src/platformUtils.ts
@@ -16,7 +16,7 @@ import { Connection, ParsedAccountData, PublicKey } from '@solana/web3.js';
 import { solGenesisHashToNetworkChainPair } from './constants';
 import { SolanaPlatform } from './platform';
 import { SolanaAddress, SolanaZeroAddress } from './address';
-import { AnySolanaAddress, toSolanaAddrPublicKey, toSolanaAddrString } from './types';
+import { AnySolanaAddress } from './types';
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
 
 // forces SolanaUtils to implement PlatformUtils
@@ -79,7 +79,7 @@ export module SolanaUtils {
 
     const splToken = await rpc.getTokenAccountsByOwner(
       new PublicKey(walletAddress),
-      { mint: toSolanaAddrPublicKey(token) },
+      { mint: new SolanaAddress(token).unwrap() },
     );
     if (!splToken.value[0]) return null;
 
@@ -106,13 +106,13 @@ export module SolanaUtils {
         },
       );
 
-    const balancesArr = tokens.map((address) => {
-      if (address === 'native') {
+    const balancesArr = tokens.map((token) => {
+      if (token === 'native') {
         return { ['native']: native };
       }
-      const addrString = toSolanaAddrString(address);
+      const addrString = new SolanaAddress(token).toString();
       const amount = splParsedTokenAccounts.value.find(
-        (v) => v?.account.data.parsed?.info?.mint === address,
+        (v) => v?.account.data.parsed?.info?.mint === token,
       )?.account.data.parsed?.info?.tokenAmount?.amount;
       if (!amount) return { [addrString]: null };
       return { [addrString]: BigInt(amount) };

--- a/platforms/solana/src/platformUtils.ts
+++ b/platforms/solana/src/platformUtils.ts
@@ -9,7 +9,6 @@ import {
   nativeDecimals,
   PlatformUtils,
   chainToPlatform,
-  UniversalOrNative,
   Balances,
 } from '@wormhole-foundation/connect-sdk';
 import { Connection, ParsedAccountData, PublicKey } from '@solana/web3.js';
@@ -49,12 +48,12 @@ export module SolanaUtils {
   export async function getDecimals(
     chain: ChainName,
     rpc: Connection,
-    token: UniversalOrNative<'Solana'> | 'native',
+    token: AnySolanaAddress | 'native',
   ): Promise<bigint> {
     if (token === 'native') return nativeDecimals(SolanaPlatform.platform);
 
     let mint = await rpc.getParsedAccountInfo(
-      new PublicKey(token.toUint8Array()),
+      new SolanaAddress(token).unwrap(),
     );
 
     if (!mint || !mint.value) throw new Error('could not fetch token details');

--- a/platforms/solana/src/protocols/tokenBridge.ts
+++ b/platforms/solana/src/protocols/tokenBridge.ts
@@ -58,8 +58,9 @@ import {
 
 import { SolanaContracts } from '../contracts';
 import { SolanaUnsignedTransaction } from '../unsignedTransaction';
-import { SolanaChainName, UniversalOrSolana } from '../types';
+import { AnySolanaAddress, SolanaChainName } from '../types';
 import { SolanaPlatform } from '../platform';
+import { SolanaAddress } from '../address';
 
 export class SolanaTokenBridge implements TokenBridge<'Solana'> {
   readonly chainId: ChainId;
@@ -86,27 +87,28 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
     return new SolanaTokenBridge(network, chain, connection, contracts);
   }
 
-  async isWrappedAsset(token: UniversalOrSolana): Promise<boolean> {
+  async isWrappedAsset(token: AnySolanaAddress): Promise<boolean> {
     return getWrappedMeta(
       this.connection,
       this.tokenBridge.programId,
-      token.toUint8Array(),
+      new SolanaAddress(token).toUint8Array(),
     )
       .catch((_) => null)
       .then((meta) => meta != null);
   }
 
-  async getOriginalAsset(token: UniversalOrSolana): Promise<TokenId> {
+  async getOriginalAsset(token: AnySolanaAddress): Promise<TokenId> {
     if (!(await this.isWrappedAsset(token)))
       throw ErrNotWrapped(token.toString());
 
-    const mint = new PublicKey(token.toUint8Array());
+    const tokenAddr = new SolanaAddress(token).toUint8Array()
+    const mint = new PublicKey(tokenAddr);
 
     try {
       const meta = await getWrappedMeta(
         this.connection,
         this.tokenBridge.programId,
-        token.toUint8Array(),
+        tokenAddr,
       );
 
       if (meta === null)
@@ -165,10 +167,11 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
   }
 
   async *createAttestation(
-    token: UniversalOrSolana,
-    sender: UniversalOrSolana,
+    token: AnySolanaAddress,
+    payer?: AnySolanaAddress,
   ): AsyncGenerator<SolanaUnsignedTransaction> {
-    const senderAddress = new PublicKey(sender.toUint8Array());
+    if (!payer) throw new Error("Payer required to create attestation");
+    const senderAddress = new SolanaAddress(payer).unwrap();
     // TODO:
     const nonce = 0; // createNonce().readUInt32LE(0);
 
@@ -183,7 +186,7 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
       this.tokenBridge.programId,
       this.coreBridge.programId,
       senderAddress,
-      token.toUint8Array(),
+      new SolanaAddress(token).toUint8Array(),
       messageKey.publicKey,
       nonce,
     );
@@ -199,9 +202,10 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
 
   async *submitAttestation(
     vaa: VAA<'AttestMeta'>,
-    sender: UniversalOrSolana,
+    payer?: AnySolanaAddress,
   ): AsyncGenerator<SolanaUnsignedTransaction> {
-    const senderAddress = new PublicKey(sender.toUint8Array());
+    if (!payer) throw new Error("Payer required to create attestation");
+    const senderAddress = new SolanaAddress(payer).unwrap();
 
     const transaction = new Transaction().add(
       createCreateWrappedInstruction(
@@ -220,15 +224,15 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
   }
 
   private async transferSol(
-    sender: UniversalOrSolana,
+    sender: AnySolanaAddress,
     recipient: ChainAddress,
     amount: bigint,
     payload?: Uint8Array,
   ): Promise<SolanaUnsignedTransaction> {
     //  https://github.com/wormhole-foundation/wormhole-connect/blob/development/sdk/src/contexts/solana/context.ts#L245
 
-    const senderAddress = new PublicKey(sender.toUint8Array());
-    // TODO: why?
+    const senderAddress = new SolanaAddress(sender).unwrap();
+    // TODO: the payer can actually be different from the sender. We need to allow the user to pass in an optional payer
     const payerPublicKey = senderAddress;
 
     const recipientAddress = recipient.address
@@ -332,9 +336,9 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
   }
 
   async *transfer(
-    sender: UniversalOrSolana,
+    sender: AnySolanaAddress,
     recipient: ChainAddress,
-    token: UniversalOrSolana | 'native',
+    token: AnySolanaAddress | 'native',
     amount: bigint,
     payload?: Uint8Array,
   ): AsyncGenerator<SolanaUnsignedTransaction> {
@@ -345,9 +349,9 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
       return;
     }
 
-    const tokenAddress = new PublicKey(token.toUint8Array());
+    const tokenAddress = new SolanaAddress(token).unwrap();
 
-    const senderAddress = new PublicKey(sender.toUint8Array());
+    const senderAddress = new SolanaAddress(sender).unwrap();
     const senderTokenAddress = await getAssociatedTokenAddress(
       tokenAddress,
       senderAddress,
@@ -454,10 +458,10 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
   }
 
   private async postVaa(
-    sender: UniversalOrSolana,
+    sender: AnySolanaAddress,
     vaa: VAA<'Transfer'> | VAA<'TransferWithPayload'>,
   ) {
-    const senderAddr = new PublicKey(sender.toUint8Array());
+    const senderAddr = new SolanaAddress(sender).unwrap();
     const signatureSet = Keypair.generate();
 
     const verifySignaturesInstructions =
@@ -495,7 +499,7 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
   }
 
   async *redeem(
-    sender: UniversalOrSolana,
+    sender: AnySolanaAddress,
     vaa: VAA<'Transfer'> | VAA<'TransferWithPayload'>,
     unwrapNative: boolean = true,
   ): AsyncGenerator<SolanaUnsignedTransaction> {
@@ -503,8 +507,8 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
     // TODO: check if vaa.payload.token.address is native Sol
 
     const { blockhash } = await this.connection.getLatestBlockhash();
-    const senderAddress = new PublicKey(sender.toUint8Array());
-    const ataAddress = new PublicKey(vaa.payload.to.address.toUint8Array());
+    const senderAddress = new SolanaAddress(sender).unwrap();
+    const ataAddress = new SolanaAddress(vaa.payload.to.address).unwrap();
     const wrappedToken = await this.getWrappedAsset(vaa.payload.token);
 
     // If the ata doesn't exist yet, create it

--- a/platforms/solana/src/protocols/tokenBridge.ts
+++ b/platforms/solana/src/protocols/tokenBridge.ts
@@ -101,7 +101,7 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
     if (!(await this.isWrappedAsset(token)))
       throw ErrNotWrapped(token.toString());
 
-    const tokenAddr = new SolanaAddress(token).toUint8Array()
+    const tokenAddr = new SolanaAddress(token).toUint8Array();
     const mint = new PublicKey(tokenAddr);
 
     try {
@@ -170,7 +170,7 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
     token: AnySolanaAddress,
     payer?: AnySolanaAddress,
   ): AsyncGenerator<SolanaUnsignedTransaction> {
-    if (!payer) throw new Error("Payer required to create attestation");
+    if (!payer) throw new Error('Payer required to create attestation');
     const senderAddress = new SolanaAddress(payer).unwrap();
     // TODO:
     const nonce = 0; // createNonce().readUInt32LE(0);
@@ -204,7 +204,7 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
     vaa: VAA<'AttestMeta'>,
     payer?: AnySolanaAddress,
   ): AsyncGenerator<SolanaUnsignedTransaction> {
-    if (!payer) throw new Error("Payer required to create attestation");
+    if (!payer) throw new Error('Payer required to create attestation');
     const senderAddress = new SolanaAddress(payer).unwrap();
 
     const transaction = new Transaction().add(

--- a/platforms/solana/src/types.ts
+++ b/platforms/solana/src/types.ts
@@ -4,6 +4,7 @@ import {
   UniversalOrNative,
   registerNative,
 } from '@wormhole-foundation/connect-sdk';
+import { PublicKeyInitData } from '@solana/web3.js';
 import { SolanaAddress } from './address';
 
 export const unusedNonce = 0;
@@ -13,11 +14,18 @@ registerNative('Solana', SolanaAddress);
 
 export type SolanaChainName = PlatformToChains<'Solana'>;
 export type UniversalOrSolana = UniversalOrNative<'Solana'>;
+export type AnySolanaAddress = UniversalOrSolana | PublicKeyInitData;
 
-export const toSolanaAddrString = (addr: UniversalOrSolana) =>
-  typeof addr === 'string'
-    ? addr
-    : (addr instanceof UniversalAddress
-        ? addr.toNative('Solana')
-        : addr
-      ).unwrap();
+export const toSolanaAddrPublicKey = (addr: AnySolanaAddress) => {
+  if (addr instanceof SolanaAddress) {
+    return addr.unwrap();
+  }
+  return new SolanaAddress(addr).unwrap()
+}
+
+export const toSolanaAddrString = (addr: AnySolanaAddress) => {
+  if (addr instanceof SolanaAddress) {
+    return addr.toString();
+  }
+  return new SolanaAddress(addr).toString()
+}

--- a/platforms/solana/src/types.ts
+++ b/platforms/solana/src/types.ts
@@ -1,15 +1,11 @@
 import {
   PlatformToChains,
   UniversalOrNative,
-  registerNative,
 } from '@wormhole-foundation/connect-sdk';
 import { PublicKeyInitData } from '@solana/web3.js';
-import { SolanaAddress } from './address';
 
 export const unusedNonce = 0;
 export const unusedArbiterFee = 0n;
-
-registerNative('Solana', SolanaAddress);
 
 export type SolanaChainName = PlatformToChains<'Solana'>;
 export type UniversalOrSolana = UniversalOrNative<'Solana'>;

--- a/platforms/solana/src/types.ts
+++ b/platforms/solana/src/types.ts
@@ -15,17 +15,3 @@ registerNative('Solana', SolanaAddress);
 export type SolanaChainName = PlatformToChains<'Solana'>;
 export type UniversalOrSolana = UniversalOrNative<'Solana'>;
 export type AnySolanaAddress = UniversalOrSolana | PublicKeyInitData;
-
-export const toSolanaAddrPublicKey = (addr: AnySolanaAddress) => {
-  if (addr instanceof SolanaAddress) {
-    return addr.unwrap();
-  }
-  return new SolanaAddress(addr).unwrap()
-}
-
-export const toSolanaAddrString = (addr: AnySolanaAddress) => {
-  if (addr instanceof SolanaAddress) {
-    return addr.toString();
-  }
-  return new SolanaAddress(addr).toString()
-}

--- a/platforms/solana/src/types.ts
+++ b/platforms/solana/src/types.ts
@@ -1,6 +1,5 @@
 import {
   PlatformToChains,
-  UniversalAddress,
   UniversalOrNative,
   registerNative,
 } from '@wormhole-foundation/connect-sdk';


### PR DESCRIPTION
Right now it just checks for native addresses.  The follow up for this would be to create an `getWrappedAssets` method, so you could call it for wrapped assets as well as native: `getBalances(getWrappedAssets(...))`