### PR TITLE
finalize automatic payload discrimination and rework VAA handling

### DIFF
--- a/__tests__/tilt/tokenbridge.test.ts
+++ b/__tests__/tilt/tokenbridge.test.ts
@@ -65,7 +65,7 @@ describe("Tilt Token Bridge Tests", () => {
             const [msgid] = await eth.parseTransaction(txns[txns.length - 1].txid)
             expect(isWormholeMessageId(msgid)).toBeTruthy()
 
-            const vaa = await wh.getVAA(msgid.chain, msgid.emitter, msgid.sequence, "AttestMeta")
+            const vaa = await wh.getVAA(msgid.chain, msgid.emitter, msgid.sequence, "TokenBridge-AttestMeta")
             expect(vaa).toBeTruthy()
 
             const completeAttest = stb.submitAttestation(vaa!, solAcct.address as SolanaAddress)

--- a/__tests__/tilt/tokenbridge.test.ts
+++ b/__tests__/tilt/tokenbridge.test.ts
@@ -65,7 +65,7 @@ describe("Tilt Token Bridge Tests", () => {
             const [msgid] = await eth.parseTransaction(txns[txns.length - 1].txid)
             expect(isWormholeMessageId(msgid)).toBeTruthy()
 
-            const vaa = await wh.getVAA(msgid.chain, msgid.emitter, msgid.sequence, "TokenBridge-AttestMeta")
+            const vaa = await wh.getVAA(msgid.chain, msgid.emitter, msgid.sequence, "TokenBridge:AttestMeta")
             expect(vaa).toBeTruthy()
 
             const completeAttest = stb.submitAttestation(vaa!, solAcct.address as SolanaAddress)

--- a/connect/src/protocols/cctpTransfer.ts
+++ b/connect/src/protocols/cctpTransfer.ts
@@ -418,7 +418,7 @@ export class CCTPTransfer implements WormholeTransfer {
     sequence: bigint,
     timeout?: number,
   ): Promise<CCTPVAA<"TransferRelay">> {
-    const vaa = await wh.getVAA(chain, emitter, sequence, "CCTP-TransferRelay", timeout);
+    const vaa = await wh.getVAA(chain, emitter, sequence, "CCTP:TransferRelay", timeout);
     if (!vaa) throw new Error(`No VAA available after timeout exhausted`);
 
     return vaa;

--- a/connect/src/protocols/cctpTransfer.ts
+++ b/connect/src/protocols/cctpTransfer.ts
@@ -13,7 +13,8 @@ import {
   TxHash,
   UniversalAddress,
   UnsignedTransaction,
-  VAA,
+  ProtocolVAA,
+  composeLiteral,
   WormholeMessageId,
   deserialize,
   deserializeCircleMessage,
@@ -33,6 +34,8 @@ import {
 } from "../wormholeTransfer";
 import { signSendWait } from "../common";
 import { DEFAULT_TASK_TIMEOUT } from "../config";
+
+export type CCTPVAA<PayloadName extends string> = ProtocolVAA<"CCTP", PayloadName>;
 
 export class CCTPTransfer implements WormholeTransfer {
   private readonly wh: Wormhole;
@@ -55,7 +58,7 @@ export class CCTPTransfer implements WormholeTransfer {
   // Populated if automatic and after initialized
   vaas?: {
     id: WormholeMessageId;
-    vaa?: VAA<"CircleTransferRelay">;
+    vaa?: CCTPVAA<"TransferRelay">;
   }[];
 
   private constructor(wh: Wormhole, transfer: CCTPTransferDetails) {
@@ -140,7 +143,7 @@ export class CCTPTransfer implements WormholeTransfer {
         //@ts-ignore
       ).toUniversalAddress();
       automatic =
-        vaa.payloadLiteral === "CircleTransferRelay" &&
+        vaa.payloadName === "TransferRelay" &&
         rcvAddress.equals(relayerAddress);
     }
 
@@ -414,15 +417,10 @@ export class CCTPTransfer implements WormholeTransfer {
     emitter: UniversalAddress | NativeAddress<PlatformName>,
     sequence: bigint,
     timeout?: number,
-  ): Promise<VAA<"CircleTransferRelay">> {
-    const vaaBytes = await wh.getVAABytes(chain, emitter, sequence, timeout);
-    if (!vaaBytes) throw new Error(`No VAA available after timeout exhausted`);
+  ): Promise<CCTPVAA<"TransferRelay">> {
+    const vaa = await wh.getVAA(chain, emitter, sequence, "CCTP-TransferRelay", timeout);
+    if (!vaa) throw new Error(`No VAA available after timeout exhausted`);
 
-    const partial = deserialize("Uint8Array", vaaBytes);
-    switch (partial.payload[0]) {
-      case 1:
-        return deserialize("CircleTransferRelay", vaaBytes);
-    }
-    throw new Error(`No serde defined for type: ${partial.payload[0]}`);
+    return vaa;
   }
 }

--- a/connect/src/tasks.ts
+++ b/connect/src/tasks.ts
@@ -8,7 +8,6 @@ import {
   TokenBridge,
   TransactionId,
   TxHash,
-  VAA,
   isGatewayTransferMsg,
   isGatewayTransferWithPayloadMsg,
   isIbcMessageId,
@@ -58,7 +57,7 @@ export async function retry<T>(
 
 export async function isTokenBridgeVaaRedeemed(
   tb: TokenBridge<PlatformName>,
-  vaa: VAA<"Transfer"> | VAA<"TransferWithPayload">,
+  vaa: TokenBridge.VAA<"Transfer" | "TransferWithPayload">,
 ): Promise<boolean | null> {
   try {
     const isRedeemed = await tb.isTransferCompleted(vaa);

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -11,7 +11,6 @@ import {
 import {
   UniversalAddress,
   deserialize,
-  VAA,
   ChainAddress,
   NativeAddress,
   TokenId,
@@ -23,6 +22,7 @@ import {
   WormholeMessageId,
   isTokenId,
   PayloadLiteral,
+  PayloadDiscriminator,
 } from "@wormhole-foundation/sdk-definitions";
 
 import { WormholeConfig } from "./types";
@@ -404,13 +404,13 @@ export class Wormhole {
    * @returns The VAA if available
    * @throws Errors if the VAA is not available after the retries
    */
-  async getVAA<PL extends PayloadLiteral>(
+  async getVAA<T extends PayloadLiteral | PayloadDiscriminator>(
     chain: ChainName,
-    emitter: UniversalAddress,
+    emitter: UniversalAddress | NativeAddress<PlatformName>,
     sequence: bigint,
-    decodeAs: PL,
+    decodeAs: T,
     timeout: number = DEFAULT_TASK_TIMEOUT,
-  ): Promise<VAA<PL> | undefined> {
+  ): Promise<ReturnType<typeof deserialize<T>> | undefined> {
     const vaaBytes = await this.getVAABytes(chain, emitter, sequence, timeout);
     if (vaaBytes === undefined) return;
     return deserialize(decodeAs, vaaBytes);

--- a/core/base/src/utils/index.ts
+++ b/core/base/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from "./layout";
 export * from "./mapping";
 export * from "./metaprogramming";
 export * from "./amount";
+export * from "./misc";

--- a/core/base/src/utils/misc.ts
+++ b/core/base/src/utils/misc.ts
@@ -1,0 +1,8 @@
+export function lazyInstantiate<T>(factory: () => T): () => T {
+  let instance: T | null = null;
+  return () => {
+    if (!instance)
+      instance = factory();
+    return instance;
+  }
+}

--- a/core/definitions/__tests__/bamVaa.ts
+++ b/core/definitions/__tests__/bamVaa.ts
@@ -2,7 +2,7 @@ import { uint8ArrayToHexByteString } from "@wormhole-foundation/sdk-base";
 import "../src/payloads/bam";
 import { deserialize, serializePayload } from "../src/vaa";
 
-const payloadLiteral = "BAM-Message";
+const payloadLiteral = "BAM:Message";
 const goerliBamAppAddress = "0x44fbfee0af8efa9e580760844f6159a8e2124b53";
 // these two contracts are deployed at the same address, made 2 variables to avoid confusion
 const baseGoerliBamAppAddress = goerliBamAppAddress;

--- a/core/definitions/__tests__/bamVaa.ts
+++ b/core/definitions/__tests__/bamVaa.ts
@@ -1,8 +1,8 @@
 import { uint8ArrayToHexByteString } from "@wormhole-foundation/sdk-base";
 import "../src/payloads/bam";
-import { deserialize, deserializePayload, serializePayload } from "../src/vaa";
+import { deserialize, serializePayload } from "../src/vaa";
 
-const payloadLiteral = "BamMessage";
+const payloadLiteral = "BAM-Message";
 const goerliBamAppAddress = "0x44fbfee0af8efa9e580760844f6159a8e2124b53";
 // these two contracts are deployed at the same address, made 2 variables to avoid confusion
 const baseGoerliBamAppAddress = goerliBamAppAddress;

--- a/core/definitions/__tests__/connectVAA.ts
+++ b/core/definitions/__tests__/connectVAA.ts
@@ -12,7 +12,7 @@ describe("CCTP Transfer VAA tests", function () {
 
       const parsed = deserialize("Uint8Array", new Uint8Array(vaaBytes));
 
-      const x = deserializePayload("CCTP-TransferRelay", parsed.payload);
+      const x = deserializePayload("CCTP:TransferRelay", parsed.payload);
       expect(x).toBeTruthy();
       // ...
     }

--- a/core/definitions/__tests__/connectVAA.ts
+++ b/core/definitions/__tests__/connectVAA.ts
@@ -5,14 +5,14 @@ const cases = [
   "AQAAAAABANyb1oS4sD9gIp0m+dKOYmrEaxx3OeWWtUbim+6oL7VnX/zUXa/di9lA0SSDRZ3DCWoqgDC4pjPoMNUNLn1P3EcAZJjzeAAAAAAAAgAAAAAAAAAAAAAAAAppFGcWs6IWIih++hYHQkxmMGmkAAAAAAAAAHDIAQAAAAAAAAAAAAAAAAeGXG6HufcCVTd+AkrOZjDB6qN/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB6EgAAAAAAAAAAAwAAAAAAA5CKAAAAAAAAAAAAAAAAF9of9ThtBExj8AdHtbitHjgGRI0AAAAAAAAAAAAAAAC/aD1UHhEyBBjKeOwTMJk45sWSLwBhAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYagAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAInU4Tn/aAHroyfjAatH6hXg4Srg==",
 ];
 
-describe("Circle Transfer VAA tests", function () {
-  it("should correctly deserialize and reserialize a Circle Transfer Relay VAA", function () {
+describe("CCTP Transfer VAA tests", function () {
+  it("should correctly deserialize and reserialize a CCTP Transfer Relay VAA", function () {
     for (const testCase of cases) {
       const vaaBytes = Buffer.from(testCase, "base64");
 
       const parsed = deserialize("Uint8Array", new Uint8Array(vaaBytes));
 
-      const x = deserializePayload("CircleTransferRelay", parsed.payload);
+      const x = deserializePayload("CCTP-TransferRelay", parsed.payload);
       expect(x).toBeTruthy();
       // ...
     }

--- a/core/definitions/__tests__/governanceVaa.ts
+++ b/core/definitions/__tests__/governanceVaa.ts
@@ -2,8 +2,15 @@ import { describe, expect, it } from "@jest/globals";
 
 import { hexByteStringToUint8Array } from "@wormhole-foundation/sdk-base";
 import { UniversalAddress } from "../src/universalAddress";
-import { create, deserialize, deserializePayload, serialize } from "../src/vaa";
-import { governancePayloadDiscriminator } from "../src/payloads/governance";
+import {
+  createVAA,
+  deserialize,
+  deserializePayload,
+  serialize,
+  blindDeserializePayload,
+  payloadDiscriminator,
+} from "../src/vaa";
+import "../src/payloads/governance";
 
 //monkey-patch to allow stringifying BigInts
 (BigInt.prototype as any).toJSON = function () {
@@ -101,8 +108,26 @@ const guardianSetUpgrade =
   /*guardian*/ "6fbebc898f403e4773e95feb15e80c9a99c8348d";
 
 describe("Governance VAA tests", function () {
+  const governanceDiscriminator = payloadDiscriminator([
+    ["CoreBridge",
+      ["UpgradeContract", "GuardianSetUpgrade", "SetMessageFee", "TransferFees", "RecoverChainId"]
+    ],
+    ["TokenBridge",
+      ["RegisterChain", "UpgradeContract", "RecoverChainId"]
+    ],
+    ["NftBridge",
+      ["RegisterChain", "UpgradeContract", "RecoverChainId"]
+    ],
+    ["Relayer",
+      ["RegisterChain", "UpgradeContract", "UpdateDefaultProvider"]
+    ],
+    ["CCTP",
+      ["UpdateFinality", "RegisterEmitterAndDomain", "UpgradeContract"]
+    ]
+  ]);
+
   it("should create an empty VAA from an object with omitted fixed values", function () {
-    const vaa = create("CoreBridgeUpgradeContract", {
+    const vaa = createVAA("CoreBridge-UpgradeContract", {
       guardianSet: 0,
       signatures: [],
       nonce: 0,
@@ -123,11 +148,11 @@ describe("Governance VAA tests", function () {
 
   it("should correctly deserialize and reserialize a guardian set upgrade VAA", function () {
     const rawvaa = deserialize("Uint8Array", guardianSetUpgrade);
-    expect(governancePayloadDiscriminator(rawvaa.payload)).toBe("CoreBridgeGuardianSetUpgrade");
-    const payload = deserializePayload("CoreBridgeGuardianSetUpgrade", rawvaa.payload);
-    const vaa = deserialize("CoreBridgeGuardianSetUpgrade", guardianSetUpgrade);
+    expect(governanceDiscriminator(rawvaa.payload)).toBe("CoreBridge-GuardianSetUpgrade");
+    const payload = deserializePayload("CoreBridge-GuardianSetUpgrade", rawvaa.payload);
+    const vaa = deserialize("CoreBridge-GuardianSetUpgrade", guardianSetUpgrade);
     expect(vaa.payload).toEqual(payload);
-    expect(vaa.payloadLiteral).toBe("CoreBridgeGuardianSetUpgrade");
+    expect(vaa.payloadLiteral).toBe("CoreBridge-GuardianSetUpgrade");
     expect(vaa.guardianSet).toBe(2);
     expect(vaa.signatures.length).toBe(13);
     expect(vaa.nonce).toBe(2651610618);
@@ -137,6 +162,9 @@ describe("Governance VAA tests", function () {
     expect(vaa.payload.guardianSet).toBe(3);
     expect(vaa.payload.guardians.length).toBe(19);
 
-    expect(serialize(vaa)).toEqual(hexByteStringToUint8Array(guardianSetUpgrade));
+    expect(serialize(vaa))
+      .toEqual(hexByteStringToUint8Array(guardianSetUpgrade));
+    expect(blindDeserializePayload(rawvaa.payload))
+      .toEqual([["CoreBridge-GuardianSetUpgrade", vaa.payload]]);
   });
 });

--- a/core/definitions/__tests__/governanceVaa.ts
+++ b/core/definitions/__tests__/governanceVaa.ts
@@ -127,7 +127,7 @@ describe("Governance VAA tests", function () {
   ]);
 
   it("should create an empty VAA from an object with omitted fixed values", function () {
-    const vaa = createVAA("CoreBridge-UpgradeContract", {
+    const vaa = createVAA("CoreBridge:UpgradeContract", {
       guardianSet: 0,
       signatures: [],
       nonce: 0,
@@ -148,11 +148,11 @@ describe("Governance VAA tests", function () {
 
   it("should correctly deserialize and reserialize a guardian set upgrade VAA", function () {
     const rawvaa = deserialize("Uint8Array", guardianSetUpgrade);
-    expect(governanceDiscriminator(rawvaa.payload)).toBe("CoreBridge-GuardianSetUpgrade");
-    const payload = deserializePayload("CoreBridge-GuardianSetUpgrade", rawvaa.payload);
-    const vaa = deserialize("CoreBridge-GuardianSetUpgrade", guardianSetUpgrade);
+    expect(governanceDiscriminator(rawvaa.payload)).toBe("CoreBridge:GuardianSetUpgrade");
+    const payload = deserializePayload("CoreBridge:GuardianSetUpgrade", rawvaa.payload);
+    const vaa = deserialize("CoreBridge:GuardianSetUpgrade", guardianSetUpgrade);
     expect(vaa.payload).toEqual(payload);
-    expect(vaa.payloadLiteral).toBe("CoreBridge-GuardianSetUpgrade");
+    expect(vaa.payloadLiteral).toBe("CoreBridge:GuardianSetUpgrade");
     expect(vaa.guardianSet).toBe(2);
     expect(vaa.signatures.length).toBe(13);
     expect(vaa.nonce).toBe(2651610618);
@@ -165,6 +165,6 @@ describe("Governance VAA tests", function () {
     expect(serialize(vaa))
       .toEqual(hexByteStringToUint8Array(guardianSetUpgrade));
     expect(blindDeserializePayload(rawvaa.payload))
-      .toEqual([["CoreBridge-GuardianSetUpgrade", vaa.payload]]);
+      .toEqual([["CoreBridge:GuardianSetUpgrade", vaa.payload]]);
   });
 });

--- a/core/definitions/__tests__/relayerVaa.ts
+++ b/core/definitions/__tests__/relayerVaa.ts
@@ -15,10 +15,10 @@ const original =
 
 describe("Relayer VAA tests", function () {
   it("should correctly deserialize and reserialize a relayer VAA", function () {
-    const payload = deserializePayload("Relayer-DeliveryInstruction", original);
+    const payload = deserializePayload("Relayer:DeliveryInstruction", original);
     expect(payload.target.chain).toBe("Polygon");
     expect(payload.refund.chain).toBe("Polygon");
-    const encoded = serializePayload("Relayer-DeliveryInstruction", payload);
+    const encoded = serializePayload("Relayer:DeliveryInstruction", payload);
     expect(encoded).toEqual(hexByteStringToUint8Array(original));
   });
 });

--- a/core/definitions/__tests__/relayerVaa.ts
+++ b/core/definitions/__tests__/relayerVaa.ts
@@ -15,10 +15,10 @@ const original =
 
 describe("Relayer VAA tests", function () {
   it("should correctly deserialize and reserialize a relayer VAA", function () {
-    const payload = deserializePayload("DeliveryInstruction", original);
+    const payload = deserializePayload("Relayer-DeliveryInstruction", original);
     expect(payload.target.chain).toBe("Polygon");
     expect(payload.refund.chain).toBe("Polygon");
-    const encoded = serializePayload("DeliveryInstruction", payload);
+    const encoded = serializePayload("Relayer-DeliveryInstruction", payload);
     expect(encoded).toEqual(hexByteStringToUint8Array(original));
   });
 });

--- a/core/definitions/__tests__/transferVaa.ts
+++ b/core/definitions/__tests__/transferVaa.ts
@@ -1,28 +1,21 @@
-import { VAA, deserialize } from "../src/vaa";
+import { payloadDiscriminator, deserialize } from "../src/vaa";
 import "../src/payloads/tokenBridge";
-import { tokenBridgePayloads } from "../src/payloads/tokenBridge";
 
 const cases = [
-  "AQAAAAABAMysWsb94YzZxLiJtKr4hcT2qA/+8laXmeZiEtmVZ5kidTdadwYiXfowVtlUtMWNv1PHIU/eH4T1EI/aI6uhW/kBZN0dygAAAAAADgAAAAAAAAAAAAAAAAXKYDfsUfi3Eu0ub6ciGf6udOFTAAAAAAAAAdUBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUk2Xpn9Q9KBiwox09gcDrskCipQADgAAAAAAAAAAAAAAAGYDtKfinfvbYVnDlakV50dXwfsTAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-  "AQAAAAABAD/A72/ZwTe/pPNRmPLLf3qZY+od9NEqvGEFBv0lHhgJdBmBo4m9cBn2Fb/03XkfFrwM00YQgnmM883tENNnBY8BZOWtSQg8AQAABgAAAAAAAAAAAAAAAGHkTlBspWWebAu6m2eFhvotcpdWAAAAAAAAHWcBAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHoSAAAAAAAAAAAAAAAAAnDySg9PkSFRpfNItP6okDPsDKIkABW2a5rLTM8HWUwGlnaPu04jKXcYMsSSWWEt1y+axX9vtACAAAAAAAAAAAAAAAADUkwZkmKzkCQWf2kwbzS5z2M/+AXsiYmFzaWNfcmVjaXBpZW50Ijp7InJlY2lwaWVudCI6ImMyVnBNVFJqTldVM1pYWjJZM0JvZFdvMGFEaHVjWGxrWm01ek16SXdPWFptYW5SbWFtUndaVGhqIn19",
+  ["Transfer", "AQAAAAABAMysWsb94YzZxLiJtKr4hcT2qA/+8laXmeZiEtmVZ5kidTdadwYiXfowVtlUtMWNv1PHIU/eH4T1EI/aI6uhW/kBZN0dygAAAAAADgAAAAAAAAAAAAAAAAXKYDfsUfi3Eu0ub6ciGf6udOFTAAAAAAAAAdUBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUk2Xpn9Q9KBiwox09gcDrskCipQADgAAAAAAAAAAAAAAAGYDtKfinfvbYVnDlakV50dXwfsTAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="],
+  ["TransferWithPayload", "AQAAAAABAD/A72/ZwTe/pPNRmPLLf3qZY+od9NEqvGEFBv0lHhgJdBmBo4m9cBn2Fb/03XkfFrwM00YQgnmM883tENNnBY8BZOWtSQg8AQAABgAAAAAAAAAAAAAAAGHkTlBspWWebAu6m2eFhvotcpdWAAAAAAAAHWcBAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHoSAAAAAAAAAAAAAAAAAnDySg9PkSFRpfNItP6okDPsDKIkABW2a5rLTM8HWUwGlnaPu04jKXcYMsSSWWEt1y+axX9vtACAAAAAAAAAAAAAAAADUkwZkmKzkCQWf2kwbzS5z2M/+AXsiYmFzaWNfcmVjaXBpZW50Ijp7InJlY2lwaWVudCI6ImMyVnBNVFJqTldVM1pYWjJZM0JvZFdvMGFEaHVjWGxrWm01ek16SXdPWFptYW5SbWFtUndaVGhqIn19"],
 ];
 
 //const original =
 describe("Token Transfer VAA tests", function () {
+  const discriminator = payloadDiscriminator(
+    ["TokenBridge", ["AttestMeta", "Transfer", "TransferWithPayload"]]
+  );
   it("should correctly deserialize and reserialize a transfer VAA", function () {
-    for (const testCase of cases) {
-      const vaaBytes = new Uint8Array(Buffer.from(testCase, "base64"));
-      let parsed:
-        | VAA<"Transfer" | "TransferWithPayload" | "AttestMeta">
-        | undefined;
-      for (const maybeType of tokenBridgePayloads) {
-        try {
-          parsed = deserialize(maybeType[0], vaaBytes);
-        } catch (e) {}
-      }
-      if (parsed === undefined) {
-        throw new Error(`Couldn't deserialize VAA: ${testCase}`);
-      }
+    for (const [payloadName, encoded] of cases) {
+      const vaaBytes = new Uint8Array(Buffer.from(encoded, "base64"));
+      const vaa = deserialize(discriminator, vaaBytes);
+      expect(vaa.payloadName).toBe(payloadName);
     }
   });
 });

--- a/core/definitions/src/payloads/relayer.ts
+++ b/core/definitions/src/payloads/relayer.ts
@@ -10,7 +10,7 @@ import {
   sequenceItem,
   amountItem,
 } from "../layout-items";
-import { NamedPayloads, payloadDiscriminator, registerPayloadType } from "../vaa";
+import { NamedPayloads, RegisterPayloadTypes, registerPayloadTypes } from "../vaa";
 
 const encodedExecutionInfoItem = {
   binary: "object",
@@ -47,7 +47,7 @@ const vaaKeyLayout = [
   { name: "sequence", ...sequenceItem },
 ] as const satisfies Layout;
 
-const relayerPayloads = [
+const namedPayloads = [
   [
     "DeliveryInstruction",
     [
@@ -87,17 +87,13 @@ const relayerPayloads = [
   ],
 ] as const satisfies NamedPayloads;
 
-export const relayerPayloadDiscriminator = payloadDiscriminator(relayerPayloads);
-
 // factory registration:
 
 declare global {
   namespace Wormhole {
     interface PayloadLiteralToLayoutMapping
-      extends ShallowMapping<typeof relayerPayloads> {}
+      extends RegisterPayloadTypes<"Relayer", typeof namedPayloads> {}
   }
 }
 
-relayerPayloads.forEach(([payloadLiteral, layout]) =>
-  registerPayloadType(payloadLiteral, layout)
-);
+registerPayloadTypes("Relayer", namedPayloads);

--- a/core/definitions/src/payloads/tokenBridge.ts
+++ b/core/definitions/src/payloads/tokenBridge.ts
@@ -4,10 +4,9 @@ import {
   CustomConversion,
   FixedSizeBytesLayoutItem,
   range,
-  ShallowMapping,
 } from "@wormhole-foundation/sdk-base";
 import { payloadIdItem, chainItem, universalAddressItem, amountItem } from "../layout-items";
-import { NamedPayloads, payloadDiscriminator, registerPayloadType } from "../vaa";
+import { NamedPayloads, RegisterPayloadTypes, registerPayloadTypes } from "../vaa";
 
 const fixedLengthStringItem = {
   binary: "bytes",
@@ -22,7 +21,7 @@ const fixedLengthStringItem = {
   } satisfies CustomConversion<Uint8Array, string>,
 } as const satisfies Omit<FixedSizeBytesLayoutItem, "name">;
 
-export const transferWithPayloadLayout = <const P extends Omit<LayoutItem, "name">>(
+export const transferWithPayloadLayout = <P extends Omit<LayoutItem, "name">>(
   customPayload: P
 ) => ([
   payloadIdItem(3),
@@ -51,7 +50,7 @@ const transferCommonLayout = [
   },
 ] as const satisfies Layout;
 
-export const tokenBridgePayloads = [
+export const namedPayloads = [
   [
     "AttestMeta",
     [
@@ -79,17 +78,13 @@ export const tokenBridgePayloads = [
   ],
 ] as const satisfies NamedPayloads;
 
-export const tokenBridgePayloadDiscriminator = payloadDiscriminator(tokenBridgePayloads);
-
 // factory registration:
 
 declare global {
   namespace Wormhole {
     interface PayloadLiteralToLayoutMapping
-      extends ShallowMapping<typeof tokenBridgePayloads> {}
+      extends RegisterPayloadTypes<"TokenBridge", typeof namedPayloads> {}
   }
 }
 
-tokenBridgePayloads.forEach(([payloadLiteral, layout]) =>
-  registerPayloadType(payloadLiteral, layout)
-);
+registerPayloadTypes("TokenBridge", namedPayloads);

--- a/core/definitions/src/testing/mocks/tokenBridge.ts
+++ b/core/definitions/src/testing/mocks/tokenBridge.ts
@@ -6,7 +6,6 @@ import {
   RpcConnection,
   TokenBridge,
   UnsignedTransaction,
-  VAA,
 } from "../..";
 
 //export function mockTokenBridgeFactory(
@@ -31,7 +30,7 @@ export class MockTokenBridge<P extends PlatformName> implements TokenBridge<P> {
     throw new Error("Method not implemented.");
   }
   isTransferCompleted(
-    vaa: VAA<"Transfer"> | VAA<"TransferWithPayload">,
+    vaa: TokenBridge.VAA<"Transfer" | "TransferWithPayload">,
   ): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
@@ -39,7 +38,7 @@ export class MockTokenBridge<P extends PlatformName> implements TokenBridge<P> {
     throw new Error("Method not implemented.");
   }
   submitAttestation(
-    vaa: VAA<"AttestMeta">,
+    vaa: TokenBridge.VAA<"AttestMeta">,
   ): AsyncGenerator<UnsignedTransaction> {
     throw new Error("Method not implemented.");
   }
@@ -54,7 +53,7 @@ export class MockTokenBridge<P extends PlatformName> implements TokenBridge<P> {
   }
   redeem(
     sender: AnyAddress,
-    vaa: VAA<"Transfer"> | VAA<"TransferWithPayload">,
+    vaa: TokenBridge.VAA<"Transfer" | "TransferWithPayload">,
     unwrapNative?: boolean | undefined,
   ): AsyncGenerator<UnsignedTransaction> {
     throw new Error("Method not implemented.");

--- a/core/definitions/src/vaa.ts
+++ b/core/definitions/src/vaa.ts
@@ -46,7 +46,7 @@ type LayoutLiteralToPayloadType<LL extends LayoutLiteral> = LayoutToType<LayoutO
 type ProtocolName = string | null;
 
 type ToLiteralFormat<PN extends ProtocolName, PayloadName extends string> =
-  PN extends null ? PayloadName : `${PN}-${PayloadName}`;
+  PN extends null ? PayloadName : `${PN}:${PayloadName}`;
 
 type ComposeLiteral<ProtocolN extends ProtocolName, PayloadN extends string, Literal> =
   ToLiteralFormat<ProtocolN, PayloadN> extends infer L extends Literal ? L : never;
@@ -55,7 +55,7 @@ export const composeLiteral = <ProtocolN extends ProtocolName, PayloadN extends 
   protocol: ProtocolN,
   payloadName: PayloadN
 ) => (
-  protocol ? `${protocol}-${payloadName}` : payloadName
+  protocol ? `${protocol}:${payloadName}` : payloadName
 ) as ComposeLiteral<ProtocolN, PayloadN, PayloadLiteral>;
 
 export type PayloadLiteral = LayoutLiteral | "Uint8Array";
@@ -63,12 +63,12 @@ type PayloadLiteralToPayloadType<PL extends PayloadLiteral> =
   PL extends LayoutLiteral ? LayoutLiteralToPayloadType<PL> : Uint8Array;
 
 type DecomposeLiteral<PL extends PayloadLiteral> =
-  PL extends `${infer Protocol}-${infer LayoutName}`
+  PL extends `${infer Protocol}:${infer LayoutName}`
   ? [Protocol, LayoutName]
   : [null, PL];
 
 const decomposeLiteral = <PL extends PayloadLiteral>(payloadLiteral: PL) => {
-  const index = payloadLiteral.indexOf("-");
+  const index = payloadLiteral.indexOf(":");
   return (index !== -1
     ? [payloadLiteral.slice(0, index), payloadLiteral.slice(index + 1)]
     : [null, payloadLiteral]) as DecomposeLiteral<PL>;
@@ -120,9 +120,9 @@ export interface VAA<PL extends PayloadLiteral = PayloadLiteral>
 //We enforce distribution over union types, e.g. have
 //    ProtocolVAA<"TokenBridge", "Transfer" | "TransferWithPayload">
 //  turned into
-//    VAA<"TokenBridge-Transfer"> | VAA<"TokenBridge-TransferWithPayload">
+//    VAA<"TokenBridge:Transfer"> | VAA<"TokenBridge:TransferWithPayload">
 //  rather than
-//    VAA<"TokenBridge-Transfer" | "TokenBridge-TransferWithPayload">
+//    VAA<"TokenBridge:Transfer" | "TokenBridge:TransferWithPayload">
 //  because while the latter is considered more idiomatic/canonical, it actually interferes with
 //  the most natural way to narrow VAAs via querying the payloadName or payloadLiteral.
 //  (Thanks for absolutely nothing, Typescript).

--- a/platforms/cosmwasm/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/cosmwasm/__tests__/integration/tokenBridge.test.ts
@@ -156,7 +156,7 @@ describe("TokenBridge Tests", () => {
 
     test("Submit Attestation", async () => {
       // TODO: generator for this
-      const vaa = createVAA("TokenBridge-AttestMeta", {
+      const vaa = createVAA("TokenBridge:AttestMeta", {
         payload: {
           token: {
             address: nativeTokenAddress.toUniversalAddress(),

--- a/platforms/cosmwasm/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/cosmwasm/__tests__/integration/tokenBridge.test.ts
@@ -3,9 +3,9 @@ import {
   chainConfigs,
   DEFAULT_NETWORK,
   testing,
-  VAA,
   Signature,
   ChainName,
+  createVAA,
 } from "@wormhole-foundation/connect-sdk";
 import {
   CosmwasmContracts,
@@ -156,8 +156,7 @@ describe("TokenBridge Tests", () => {
 
     test("Submit Attestation", async () => {
       // TODO: generator for this
-      const vaa: VAA<"AttestMeta"> = {
-        payloadLiteral: "AttestMeta",
+      const vaa = createVAA("TokenBridge-AttestMeta", {
         payload: {
           token: {
             address: nativeTokenAddress.toUniversalAddress(),
@@ -167,7 +166,6 @@ describe("TokenBridge Tests", () => {
           symbol: Buffer.from(new Uint8Array(16)).toString("hex"),
           name: Buffer.from(new Uint8Array(16)).toString("hex"),
         },
-        hash: new Uint8Array(32),
         guardianSet: 0,
         signatures: [{ guardianIndex: 0, signature: new Signature(1n, 2n, 1) }],
         emitterChain: chain,
@@ -176,7 +174,7 @@ describe("TokenBridge Tests", () => {
         consistencyLevel: 0,
         timestamp: 0,
         nonce: 0,
-      };
+      });
       const submitAttestation = tb.submitAttestation(vaa, senderAddress);
 
       const allTxns: CosmwasmUnsignedTransaction[] = [];

--- a/platforms/cosmwasm/src/protocols/tokenBridge.ts
+++ b/platforms/cosmwasm/src/protocols/tokenBridge.ts
@@ -1,7 +1,6 @@
 import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import {
   Network,
-  VAA,
   ChainAddress,
   TokenBridge,
   TxHash,
@@ -109,7 +108,7 @@ export class CosmwasmTokenBridge implements TokenBridge<"Cosmwasm"> {
   }
 
   async isTransferCompleted(
-    vaa: VAA<"Transfer"> | VAA<"TransferWithPayload">,
+    vaa: TokenBridge.VAA<"Transfer" | "TransferWithPayload">,
   ): Promise<boolean> {
     const data = Buffer.from(serialize(vaa)).toString("base64");
     const result = await this.rpc.queryContractSmart(this.tokenBridge, {
@@ -155,7 +154,7 @@ export class CosmwasmTokenBridge implements TokenBridge<"Cosmwasm"> {
   }
 
   async *submitAttestation(
-    vaa: VAA<"AttestMeta">,
+    vaa: TokenBridge.VAA<"AttestMeta">,
     payer?: AnyCosmwasmAddress,
   ): AsyncGenerator<CosmwasmUnsignedTransaction> {
     if (!payer) throw new Error("Payer required to submit attestation");
@@ -279,7 +278,7 @@ export class CosmwasmTokenBridge implements TokenBridge<"Cosmwasm"> {
 
   async *redeem(
     sender: AnyCosmwasmAddress,
-    vaa: VAA<"Transfer"> | VAA<"TransferWithPayload">,
+    vaa: TokenBridge.VAA<"Transfer" | "TransferWithPayload">,
     unwrapNative: boolean = true,
   ): AsyncGenerator<CosmwasmUnsignedTransaction> {
     // TODO: unwrapNative

--- a/platforms/evm/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/evm/__tests__/integration/tokenBridge.test.ts
@@ -4,11 +4,11 @@ import {
   Signature,
   TokenBridge,
   UniversalAddress,
-  VAA,
   testing,
   toNative,
   chainConfigs,
   DEFAULT_NETWORK,
+  createVAA,
 } from '@wormhole-foundation/connect-sdk';
 
 import {
@@ -232,15 +232,13 @@ describe('TokenBridge Tests', () => {
 
     test('Submit Attestation', async () => {
       // TODO: generator for this
-      const vaa: VAA<'AttestMeta'> = {
-        payloadLiteral: 'AttestMeta',
+      const vaa = createVAA('TokenBridge-AttestMeta', {
         payload: {
           token: { address: nativeAddress.toUniversalAddress(), chain: chain },
           decimals: 8,
           symbol: Buffer.from(new Uint8Array(16)).toString('hex'),
           name: Buffer.from(new Uint8Array(16)).toString('hex'),
         },
-        hash: new Uint8Array(32),
         guardianSet: 0,
         signatures: [{ guardianIndex: 0, signature: new Signature(1n, 2n, 1) }],
         emitterChain: chain,
@@ -249,7 +247,7 @@ describe('TokenBridge Tests', () => {
         consistencyLevel: 0,
         timestamp: 0,
         nonce: 0,
-      };
+      });
       const submitAttestation = tb.submitAttestation(vaa);
 
       const allTxns: EvmUnsignedTransaction[] = [];

--- a/platforms/evm/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/evm/__tests__/integration/tokenBridge.test.ts
@@ -232,7 +232,7 @@ describe('TokenBridge Tests', () => {
 
     test('Submit Attestation', async () => {
       // TODO: generator for this
-      const vaa = createVAA('TokenBridge-AttestMeta', {
+      const vaa = createVAA('TokenBridge:AttestMeta', {
         payload: {
           token: { address: nativeAddress.toUniversalAddress(), chain: chain },
           decimals: 8,

--- a/platforms/evm/src/protocols/automaticTokenBridge.ts
+++ b/platforms/evm/src/protocols/automaticTokenBridge.ts
@@ -1,7 +1,7 @@
 import {
   ChainAddress,
   AutomaticTokenBridge,
-  VAA,
+  TokenBridge,
   serialize,
   TokenId,
   chainToChainId,
@@ -42,7 +42,7 @@ export class EvmAutomaticTokenBridge implements AutomaticTokenBridge<'Evm'> {
   }
   async *redeem(
     sender: AnyEvmAddress,
-    vaa: VAA<'TransferWithPayload'>,
+    vaa: TokenBridge.VAA<'TransferWithPayload'>,
   ): AsyncGenerator<EvmUnsignedTransaction> {
     const senderAddr = new EvmAddress(sender).toString();
     const txReq =

--- a/platforms/solana/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/solana/__tests__/integration/tokenBridge.test.ts
@@ -3,10 +3,10 @@ import {
   Platform,
   testing,
   toNative,
-  VAA,
   Signature,
   chainConfigs,
   DEFAULT_NETWORK,
+  createVAA,
 } from '@wormhole-foundation/connect-sdk';
 
 import {
@@ -202,8 +202,7 @@ describe('TokenBridge Tests', () => {
 
     test('Submit Attestation', async () => {
       // TODO: generator for this
-      const vaa: VAA<'AttestMeta'> = {
-        payloadLiteral: 'AttestMeta',
+      const vaa = createVAA('TokenBridge-AttestMeta', {
         payload: {
           token: {
             address: nativeAddress.toUniversalAddress(),
@@ -213,7 +212,6 @@ describe('TokenBridge Tests', () => {
           symbol: Buffer.from(new Uint8Array(16)).toString('hex'),
           name: Buffer.from(new Uint8Array(16)).toString('hex'),
         },
-        hash: new Uint8Array(32),
         guardianSet: 3,
         signatures: [{ guardianIndex: 0, signature: new Signature(1n, 2n, 1) }],
         emitterChain: 'Avalanche',
@@ -222,7 +220,7 @@ describe('TokenBridge Tests', () => {
         consistencyLevel: 0,
         timestamp: 0,
         nonce: 0,
-      };
+      });
       const submitAttestation = tb.submitAttestation(vaa, sender);
 
       const allTxns: SolanaUnsignedTransaction[] = [];

--- a/platforms/solana/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/solana/__tests__/integration/tokenBridge.test.ts
@@ -202,7 +202,7 @@ describe('TokenBridge Tests', () => {
 
     test('Submit Attestation', async () => {
       // TODO: generator for this
-      const vaa = createVAA('TokenBridge-AttestMeta', {
+      const vaa = createVAA('TokenBridge:AttestMeta', {
         payload: {
           token: {
             address: nativeAddress.toUniversalAddress(),

--- a/platforms/solana/src/protocols/tokenBridge.ts
+++ b/platforms/solana/src/protocols/tokenBridge.ts
@@ -5,7 +5,6 @@ import {
   toChainName,
   TokenBridge,
   ChainAddress,
-  VAA,
   TokenId,
   UniversalAddress,
   toNative,
@@ -154,7 +153,7 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
   }
 
   async isTransferCompleted(
-    vaa: VAA<'Transfer'> | VAA<'TransferWithPayload'>,
+    vaa: TokenBridge.VAA<'Transfer' | 'TransferWithPayload'>,
   ): Promise<boolean> {
     return getClaim(
       this.connection,
@@ -205,7 +204,7 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
   }
 
   async *submitAttestation(
-    vaa: VAA<'AttestMeta'>,
+    vaa: TokenBridge.VAA<'AttestMeta'>,
     payer?: AnySolanaAddress,
   ): AsyncGenerator<SolanaUnsignedTransaction> {
     if (!payer) throw new Error('Payer required to create attestation');
@@ -468,7 +467,7 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
 
   async *redeem(
     sender: AnySolanaAddress,
-    vaa: VAA<'Transfer'> | VAA<'TransferWithPayload'>,
+    vaa: TokenBridge.VAA<'Transfer' | 'TransferWithPayload'>,
     unwrapNative: boolean = true,
   ): AsyncGenerator<SolanaUnsignedTransaction> {
     // TODO unwrapNative?
@@ -520,7 +519,7 @@ export class SolanaTokenBridge implements TokenBridge<'Solana'> {
 
   private async *postVaa(
     sender: AnySolanaAddress,
-    vaa: VAA<'Transfer'> | VAA<'TransferWithPayload'> | VAA<'AttestMeta'>,
+    vaa: TokenBridge.VAA<'Transfer' | 'TransferWithPayload' | 'AttestMeta'>,
     blockhash: string,
   ) {
     const senderAddr = new SolanaAddress(sender).unwrap();

--- a/platforms/solana/src/utils/nftBridge/instructions/governance.ts
+++ b/platforms/solana/src/utils/nftBridge/instructions/governance.ts
@@ -22,7 +22,7 @@ export function createRegisterChainInstruction(
   nftBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'NftBridge-RegisterChain'>,
+  vaa: VAA<'NftBridge:RegisterChain'>,
 ): TransactionInstruction {
   const methods = createReadOnlyNftBridgeProgramInterface(
     nftBridgeProgramId,
@@ -59,7 +59,7 @@ export function getRegisterChainAccounts(
   nftBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'NftBridge-RegisterChain'>,
+  vaa: VAA<'NftBridge:RegisterChain'>,
 ): RegisterChainAccounts {
   return {
     payer: new PublicKey(payer),
@@ -87,7 +87,7 @@ export function createUpgradeContractInstruction(
   nftBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'NftBridge-UpgradeContract'>,
+  vaa: VAA<'NftBridge:UpgradeContract'>,
   spill?: PublicKeyInitData,
 ): TransactionInstruction {
   const methods = createReadOnlyNftBridgeProgramInterface(
@@ -130,7 +130,7 @@ export function getUpgradeContractAccounts(
   nftBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'NftBridge-UpgradeContract'>,
+  vaa: VAA<'NftBridge:UpgradeContract'>,
   spill?: PublicKeyInitData,
 ): UpgradeContractAccounts {
   return {

--- a/platforms/solana/src/utils/nftBridge/instructions/governance.ts
+++ b/platforms/solana/src/utils/nftBridge/instructions/governance.ts
@@ -22,7 +22,7 @@ export function createRegisterChainInstruction(
   nftBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'NftBridgeRegisterChain'>,
+  vaa: VAA<'NftBridge-RegisterChain'>,
 ): TransactionInstruction {
   const methods = createReadOnlyNftBridgeProgramInterface(
     nftBridgeProgramId,
@@ -59,7 +59,7 @@ export function getRegisterChainAccounts(
   nftBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'NftBridgeRegisterChain'>,
+  vaa: VAA<'NftBridge-RegisterChain'>,
 ): RegisterChainAccounts {
   return {
     payer: new PublicKey(payer),
@@ -87,7 +87,7 @@ export function createUpgradeContractInstruction(
   nftBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'NftBridgeUpgradeContract'>,
+  vaa: VAA<'NftBridge-UpgradeContract'>,
   spill?: PublicKeyInitData,
 ): TransactionInstruction {
   const methods = createReadOnlyNftBridgeProgramInterface(
@@ -130,7 +130,7 @@ export function getUpgradeContractAccounts(
   nftBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'NftBridgeUpgradeContract'>,
+  vaa: VAA<'NftBridge-UpgradeContract'>,
   spill?: PublicKeyInitData,
 ): UpgradeContractAccounts {
   return {

--- a/platforms/solana/src/utils/tokenBridge/cpi.ts
+++ b/platforms/solana/src/utils/tokenBridge/cpi.ts
@@ -26,7 +26,7 @@ import {
   getTransferNativeWithPayloadAccounts,
   getTransferWrappedWithPayloadAccounts,
 } from './instructions';
-import { VAA, toChainId } from '@wormhole-foundation/connect-sdk';
+import { TokenBridge, toChainId } from '@wormhole-foundation/connect-sdk';
 
 export interface TokenBridgeBaseDerivedAccounts {
   /**
@@ -346,7 +346,7 @@ export function getCompleteTransferNativeWithPayloadCpiAccounts(
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'Transfer'> | VAA<'TransferWithPayload'>,
+  vaa: TokenBridge.VAA<'Transfer' | 'TransferWithPayload'>,
   toTokenAccount: PublicKeyInitData,
 ): CompleteTransferNativeWithPayloadCpiAccounts {
   const mint = new PublicKey(vaa.payload.token.address.toUint8Array());
@@ -433,7 +433,7 @@ export function getCompleteTransferWrappedWithPayloadCpiAccounts(
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'Transfer'> | VAA<'TransferWithPayload'>,
+  vaa: TokenBridge.VAA<'Transfer' | 'TransferWithPayload'>,
   toTokenAccount: PublicKeyInitData,
 ): CompleteTransferWrappedWithPayloadCpiAccounts {
   const mint = deriveWrappedMintKey(

--- a/platforms/solana/src/utils/tokenBridge/instructions/completeNative.ts
+++ b/platforms/solana/src/utils/tokenBridge/instructions/completeNative.ts
@@ -15,14 +15,14 @@ import {
   deriveCustodyKey,
   deriveCustodySignerKey,
 } from '../accounts';
-import { VAA, toChainId } from '@wormhole-foundation/connect-sdk';
+import { TokenBridge, toChainId } from '@wormhole-foundation/connect-sdk';
 
 export function createCompleteTransferNativeInstruction(
   connection: Connection,
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'Transfer'> | VAA<'TransferWithPayload'>,
+  vaa: TokenBridge.VAA<'Transfer' | 'TransferWithPayload'>,
   feeRecipient?: PublicKeyInitData,
 ): TransactionInstruction {
   const methods = createReadOnlyTokenBridgeProgramInterface(
@@ -67,7 +67,7 @@ export function getCompleteTransferNativeAccounts(
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'Transfer'> | VAA<'TransferWithPayload'>,
+  vaa: TokenBridge.VAA<'Transfer' | 'TransferWithPayload'>,
   feeRecipient?: PublicKeyInitData,
 ): CompleteTransferNativeAccounts {
   const mint = new PublicKey(vaa.payload.token.address.toUint8Array());

--- a/platforms/solana/src/utils/tokenBridge/instructions/completeWrapped.ts
+++ b/platforms/solana/src/utils/tokenBridge/instructions/completeWrapped.ts
@@ -16,14 +16,14 @@ import {
   deriveWrappedMetaKey,
   deriveMintAuthorityKey,
 } from '../accounts';
-import { VAA, toChainId } from '@wormhole-foundation/connect-sdk';
+import { TokenBridge, toChainId } from '@wormhole-foundation/connect-sdk';
 
 export function createCompleteTransferWrappedInstruction(
   connection: Connection,
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'Transfer'> | VAA<'TransferWithPayload'>,
+  vaa: TokenBridge.VAA<'Transfer' | 'TransferWithPayload'>,
   feeRecipient?: PublicKeyInitData,
 ): TransactionInstruction {
   const methods = createReadOnlyTokenBridgeProgramInterface(
@@ -68,7 +68,7 @@ export function getCompleteTransferWrappedAccounts(
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'Transfer'> | VAA<'TransferWithPayload'>,
+  vaa: TokenBridge.VAA<'Transfer' | 'TransferWithPayload'>,
   feeRecipient?: PublicKeyInitData,
 ): CompleteTransferWrappedAccounts {
   const mint = deriveWrappedMintKey(

--- a/platforms/solana/src/utils/tokenBridge/instructions/createWrapped.ts
+++ b/platforms/solana/src/utils/tokenBridge/instructions/createWrapped.ts
@@ -18,14 +18,14 @@ import {
   deriveWrappedMintKey,
 } from '../accounts';
 import { SplTokenMetadataProgram } from '../../utils';
-import { toChainId, VAA } from '@wormhole-foundation/connect-sdk';
+import { TokenBridge, toChainId } from '@wormhole-foundation/connect-sdk';
 
 export function createCreateWrappedInstruction(
   connection: Connection,
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'AttestMeta'>,
+  vaa: TokenBridge.VAA<'AttestMeta'>,
 ): TransactionInstruction {
   const methods = createReadOnlyTokenBridgeProgramInterface(
     tokenBridgeProgramId,
@@ -68,7 +68,7 @@ export function getCreateWrappedAccounts(
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'AttestMeta'>,
+  vaa: TokenBridge.VAA<'AttestMeta'>,
 ): CreateWrappedAccounts {
   const mint = deriveWrappedMintKey(
     tokenBridgeProgramId,

--- a/platforms/solana/src/utils/tokenBridge/instructions/governance.ts
+++ b/platforms/solana/src/utils/tokenBridge/instructions/governance.ts
@@ -14,13 +14,13 @@ import {
   deriveUpgradeAuthorityKey,
 } from '../accounts';
 import { BpfLoaderUpgradeable, deriveUpgradeableProgramKey } from '../../utils';
-import { VAA, toChainId } from '@wormhole-foundation/connect-sdk';
+import { TokenBridge, toChainId } from '@wormhole-foundation/connect-sdk';
 
 export function createRegisterChainInstruction(
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'TokenBridgeRegisterChain'>,
+  vaa: TokenBridge.VAA<'RegisterChain'>,
 ): TransactionInstruction {
   const methods =
     createReadOnlyTokenBridgeProgramInterface(
@@ -57,7 +57,7 @@ export function getRegisterChainAccounts(
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'TokenBridgeRegisterChain'>,
+  vaa: TokenBridge.VAA<'RegisterChain'>,
 ): RegisterChainAccounts {
   return {
     payer: new PublicKey(payer),
@@ -84,7 +84,7 @@ export function createUpgradeContractInstruction(
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'TokenBridgeUpgradeContract'>,
+  vaa: TokenBridge.VAA<'UpgradeContract'>,
   spill?: PublicKeyInitData,
 ): TransactionInstruction {
   const methods =
@@ -127,7 +127,7 @@ export function getUpgradeContractAccounts(
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'TokenBridgeUpgradeContract'>,
+  vaa: TokenBridge.VAA<'UpgradeContract'>,
   spill?: PublicKeyInitData,
 ): UpgradeContractAccounts {
   return {

--- a/platforms/solana/src/utils/wormhole/instructions/governance.ts
+++ b/platforms/solana/src/utils/wormhole/instructions/governance.ts
@@ -23,7 +23,7 @@ export function createSetFeesInstruction(
   connection: Connection,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridgeSetMessageFee'>,
+  vaa: VAA<'CoreBridge-SetMessageFee'>,
 ): TransactionInstruction {
   const methods = createReadOnlyWormholeProgramInterface(
     wormholeProgramId,
@@ -51,7 +51,7 @@ export interface SetFeesAccounts {
 export function getSetFeesAccounts(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridgeSetMessageFee'>,
+  vaa: VAA<'CoreBridge-SetMessageFee'>,
 ): SetFeesAccounts {
   return {
     payer: new PublicKey(payer),
@@ -72,7 +72,7 @@ export function createTransferFeesInstruction(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
   recipient: PublicKeyInitData,
-  vaa: VAA<'CoreBridgeTransferFees'>,
+  vaa: VAA<'CoreBridge-TransferFees'>,
 ): TransactionInstruction {
   const methods = createReadOnlyWormholeProgramInterface(
     wormholeProgramId,
@@ -109,7 +109,7 @@ export function getTransferFeesAccounts(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
   recipient: PublicKeyInitData,
-  vaa: VAA<'CoreBridgeTransferFees'>,
+  vaa: VAA<'CoreBridge-TransferFees'>,
 ): TransferFeesAccounts {
   return {
     payer: new PublicKey(payer),
@@ -132,7 +132,7 @@ export function createUpgradeGuardianSetInstruction(
   connection: Connection,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridgeGuardianSetUpgrade'>,
+  vaa: VAA<'CoreBridge-GuardianSetUpgrade'>,
 ): TransactionInstruction {
   const methods = createReadOnlyWormholeProgramInterface(
     wormholeProgramId,
@@ -166,7 +166,7 @@ export interface UpgradeGuardianSetAccounts {
 export function getUpgradeGuardianSetAccounts(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridgeGuardianSetUpgrade'>,
+  vaa: VAA<'CoreBridge-GuardianSetUpgrade'>,
 ): UpgradeGuardianSetAccounts {
   return {
     payer: new PublicKey(payer),
@@ -191,7 +191,7 @@ export function createUpgradeContractInstruction(
   connection: Connection,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridgeUpgradeContract'>,
+  vaa: VAA<'CoreBridge-UpgradeContract'>,
 ): TransactionInstruction {
   const methods = createReadOnlyWormholeProgramInterface(
     wormholeProgramId,
@@ -227,7 +227,7 @@ export interface UpgradeContractAccounts {
 export function getUpgradeContractAccounts(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridgeUpgradeContract'>,
+  vaa: VAA<'CoreBridge-UpgradeContract'>,
   spill?: PublicKeyInitData,
 ): UpgradeContractAccounts {
   const { newContract } = vaa.payload;

--- a/platforms/solana/src/utils/wormhole/instructions/governance.ts
+++ b/platforms/solana/src/utils/wormhole/instructions/governance.ts
@@ -23,7 +23,7 @@ export function createSetFeesInstruction(
   connection: Connection,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridge-SetMessageFee'>,
+  vaa: VAA<'CoreBridge:SetMessageFee'>,
 ): TransactionInstruction {
   const methods = createReadOnlyWormholeProgramInterface(
     wormholeProgramId,
@@ -51,7 +51,7 @@ export interface SetFeesAccounts {
 export function getSetFeesAccounts(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridge-SetMessageFee'>,
+  vaa: VAA<'CoreBridge:SetMessageFee'>,
 ): SetFeesAccounts {
   return {
     payer: new PublicKey(payer),
@@ -72,7 +72,7 @@ export function createTransferFeesInstruction(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
   recipient: PublicKeyInitData,
-  vaa: VAA<'CoreBridge-TransferFees'>,
+  vaa: VAA<'CoreBridge:TransferFees'>,
 ): TransactionInstruction {
   const methods = createReadOnlyWormholeProgramInterface(
     wormholeProgramId,
@@ -109,7 +109,7 @@ export function getTransferFeesAccounts(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
   recipient: PublicKeyInitData,
-  vaa: VAA<'CoreBridge-TransferFees'>,
+  vaa: VAA<'CoreBridge:TransferFees'>,
 ): TransferFeesAccounts {
   return {
     payer: new PublicKey(payer),
@@ -132,7 +132,7 @@ export function createUpgradeGuardianSetInstruction(
   connection: Connection,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridge-GuardianSetUpgrade'>,
+  vaa: VAA<'CoreBridge:GuardianSetUpgrade'>,
 ): TransactionInstruction {
   const methods = createReadOnlyWormholeProgramInterface(
     wormholeProgramId,
@@ -166,7 +166,7 @@ export interface UpgradeGuardianSetAccounts {
 export function getUpgradeGuardianSetAccounts(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridge-GuardianSetUpgrade'>,
+  vaa: VAA<'CoreBridge:GuardianSetUpgrade'>,
 ): UpgradeGuardianSetAccounts {
   return {
     payer: new PublicKey(payer),
@@ -191,7 +191,7 @@ export function createUpgradeContractInstruction(
   connection: Connection,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridge-UpgradeContract'>,
+  vaa: VAA<'CoreBridge:UpgradeContract'>,
 ): TransactionInstruction {
   const methods = createReadOnlyWormholeProgramInterface(
     wormholeProgramId,
@@ -227,7 +227,7 @@ export interface UpgradeContractAccounts {
 export function getUpgradeContractAccounts(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: VAA<'CoreBridge-UpgradeContract'>,
+  vaa: VAA<'CoreBridge:UpgradeContract'>,
   spill?: PublicKeyInitData,
 ): UpgradeContractAccounts {
   const { newContract } = vaa.payload;


### PR DESCRIPTION
also added/changed:
* renamed payloadliterals to include the protocol name (to get rid of the overly general Transfer payload and instead have it now as "TokenBridge-Transfer", etc.)
* added handling for such protocol-payloadName composite payload literals
* added CCTP governance payloads
* implemented lazyInstantiation helper (currently has a rather questionable placing in misc.ts)
* introduced a TokenBridge namespace for associated types/functions

still oustanding:
* not all free standing functions have been absorbed into the TokenBridge namespace
* CoreBridge does not use a namespace like TokenBridge yet
* there's more cleanup to be done (still a bunch of redundant code left)