### PR TITLE
TYPES

### DIFF
--- a/connect/src/protocols/cctpTransfer.ts
+++ b/connect/src/protocols/cctpTransfer.ts
@@ -17,12 +17,13 @@ import {
   isWormholeMessageId,
   nativeChainAddress,
   serializeCircleMessage,
+  AttestationId,
 } from "@wormhole-foundation/sdk-definitions";
 
 import { signSendWait } from "../common";
 import { DEFAULT_TASK_TIMEOUT } from "../config";
 import { Wormhole } from "../wormhole";
-import { AttestationId, TransferState, WormholeTransfer } from "../wormholeTransfer";
+import { TransferState, WormholeTransfer } from "../wormholeTransfer";
 
 export type AutomaticCircleBridgeVAA<PayloadName extends string> = ProtocolVAA<
   "AutomaticCircleBridge",

--- a/connect/src/protocols/gatewayTransfer.ts
+++ b/connect/src/protocols/gatewayTransfer.ts
@@ -28,11 +28,12 @@ import {
   nativeChainAddress,
   toGatewayMsg,
   toNative,
+  AttestationId,
 } from "@wormhole-foundation/sdk-definitions";
 import { signSendWait } from "../common";
 import { fetchIbcXfer, isTokenBridgeVaaRedeemed, retry } from "../tasks";
 import { Wormhole } from "../wormhole";
-import { AttestationId, TransferState, WormholeTransfer } from "../wormholeTransfer";
+import { TransferState, WormholeTransfer } from "../wormholeTransfer";
 
 type GatewayContext<N extends Network> = ChainContext<
   N,

--- a/connect/src/protocols/gatewayTransfer.ts
+++ b/connect/src/protocols/gatewayTransfer.ts
@@ -40,9 +40,7 @@ type GatewayContext<N extends Network> = ChainContext<
   typeof GatewayTransfer.chain
 >;
 
-export class GatewayTransfer<N extends Network = Network>
-  implements WormholeTransfer<GatewayTransferDetails>
-{
+export class GatewayTransfer<N extends Network = Network> implements WormholeTransfer<"IbcBridge"> {
   static chain: "Wormchain" = "Wormchain";
 
   private readonly wh: Wormhole<N>;

--- a/connect/src/protocols/tokenTransfer.ts
+++ b/connect/src/protocols/tokenTransfer.ts
@@ -18,13 +18,13 @@ import {
   isWormholeMessageId,
   nativeChainAddress,
   toNative,
+  AttestationId,
 } from "@wormhole-foundation/sdk-definitions";
 import { signSendWait } from "../common";
 import { DEFAULT_TASK_TIMEOUT } from "../config";
 import { Wormhole } from "../wormhole";
 import {
-  AttestationId,
-  Receipt,
+  TransferReceipt,
   TransferQuote,
   TransferState,
   WormholeTransfer,
@@ -619,7 +619,7 @@ export class TokenTransfer<N extends Network = Network>
 
   static getReceipt<N extends Network>(
     xfer: TokenTransfer<N>,
-  ): Receipt<
+  ): TransferReceipt<
     "TokenBridge" | "AutomaticTokenBridge",
     typeof xfer.transfer.from.chain,
     typeof xfer.transfer.to.chain

--- a/connect/src/wormholeTransfer.ts
+++ b/connect/src/wormholeTransfer.ts
@@ -1,36 +1,23 @@
-import { Wormhole } from "./wormhole";
 import {
+  Chain,
   Network,
   Platform,
-  Chain,
   PlatformToChains,
   ProtocolName,
 } from "@wormhole-foundation/sdk-base";
 import {
   ChainContext,
-  CircleMessageId,
   CircleTransferDetails,
   GatewayTransferDetails,
-  IbcMessageId,
   Signer,
   TokenId,
   TokenTransferDetails,
   TransactionId,
   TxHash,
   VAA,
-  WormholeMessageId,
+  AttestationId,
 } from "@wormhole-foundation/sdk-definitions";
-
-// Could be VAA or Circle or ..?
-export type AttestationId<PN extends ProtocolName = ProtocolName> = PN extends
-  | "TokenBridge"
-  | "AutomaticTokenBridge"
-  ? WormholeMessageId
-  : PN extends "CircleBridge" | "AutomaticCircleBridge"
-  ? CircleMessageId
-  : PN extends "IbcBridge"
-  ? IbcMessageId
-  : never;
+import { Wormhole } from "./wormhole";
 
 export type TransferRequest<PN extends ProtocolName = ProtocolName> = PN extends
   | "TokenBridge"
@@ -53,7 +40,11 @@ export enum TransferState {
   DestinationFinalized, // Will be set after the transaction is finalized on the destination chain
 }
 
-export type Receipt<PN extends ProtocolName, SC extends Chain = Chain, DC extends Chain = Chain> = {
+export type TransferReceipt<
+  PN extends ProtocolName,
+  SC extends Chain = Chain,
+  DC extends Chain = Chain,
+> = {
   state: TransferState;
   from: SC;
   to: DC;
@@ -99,12 +90,12 @@ export interface TransferProtocol<PN extends ProtocolName> {
   isAutomatic<N extends Network>(wh: Wormhole<N>, vaa: VAA): boolean;
   //validateTransfer<N extends Network>(wh: Wormhole<N>, transfer: )
   quoteTransfer(xfer: WormholeTransfer<PN>): Promise<TransferQuote>;
-  getReceipt(xfer: WormholeTransfer<PN>): Receipt<PN>;
+  getReceipt(xfer: WormholeTransfer<PN>): TransferReceipt<PN>;
   track<N extends Network>(
     wh: Wormhole<N>,
     xfer: WormholeTransfer<PN>,
     timeout: number,
-  ): AsyncGenerator<TransferState, Receipt<PN>, unknown>;
+  ): AsyncGenerator<TransferState, TransferReceipt<PN>, unknown>;
 }
 
 // WormholeTransfer abstracts the process and state transitions

--- a/core/definitions/src/attestation.ts
+++ b/core/definitions/src/attestation.ts
@@ -1,15 +1,14 @@
 import { Chain } from "@wormhole-foundation/sdk-base";
 import { SequenceId } from "./types";
 import { UniversalAddress } from "./universalAddress";
-import { PayloadLiteral, VAA } from "./vaa";
+import { VAA } from "./vaa";
 
 // Wormhole Message Identifier used to fetch a VAA
 // Possibly with a VAA already set
-export type WormholeMessageId<PL extends PayloadLiteral = PayloadLiteral> = {
+export type WormholeMessageId = {
   chain: Chain;
   emitter: UniversalAddress;
   sequence: SequenceId;
-  vaa?: VAA<PL>;
 };
 export function isWormholeMessageId(thing: WormholeMessageId | any): thing is WormholeMessageId {
   return (
@@ -24,13 +23,10 @@ export type getWormholeAttestation = (id: WormholeMessageId) => Promise<VAA>;
 // Circle Message Identifier
 // Used to fetch a Circle attestation
 export type CircleMessageId = {
-  message: string;
   hash: string;
 };
 export function isCircleMessageId(thing: CircleMessageId | any): thing is CircleMessageId {
-  return (
-    (<CircleMessageId>thing).message !== undefined && (<CircleMessageId>thing).hash !== undefined
-  );
+  return (<CircleMessageId>thing).hash !== undefined;
 }
 
 // Raw payload from circle

--- a/core/definitions/src/attestation.ts
+++ b/core/definitions/src/attestation.ts
@@ -1,16 +1,15 @@
 import { Chain } from "@wormhole-foundation/sdk-base";
 import { SequenceId } from "./types";
 import { UniversalAddress } from "./universalAddress";
-import { VAA } from "./vaa";
+import { PayloadLiteral, VAA } from "./vaa";
 
-// Wormhole Message Identifier
-// used to fetch a VAA
-export type WormholeMessageId<C extends Chain = Chain> = {
-  chain: C;
+// Wormhole Message Identifier used to fetch a VAA
+// Possibly with a VAA already set
+export type WormholeMessageId<PL extends PayloadLiteral = PayloadLiteral> = {
+  chain: Chain;
   emitter: UniversalAddress;
   sequence: SequenceId;
-  // TODO
-  vaa?: VAA;
+  vaa?: VAA<PL>;
 };
 export function isWormholeMessageId(thing: WormholeMessageId | any): thing is WormholeMessageId {
   return (

--- a/core/definitions/src/attestation.ts
+++ b/core/definitions/src/attestation.ts
@@ -1,7 +1,18 @@
-import { Chain } from "@wormhole-foundation/sdk-base";
+import { Chain, ProtocolName } from "@wormhole-foundation/sdk-base";
 import { SequenceId } from "./types";
 import { UniversalAddress } from "./universalAddress";
 import { VAA } from "./vaa";
+
+// Could be VAA or Circle or ..?
+export type AttestationId<PN extends ProtocolName = ProtocolName> = PN extends
+  | "TokenBridge"
+  | "AutomaticTokenBridge"
+  ? WormholeMessageId
+  : PN extends "CircleBridge" | "AutomaticCircleBridge"
+  ? CircleMessageId
+  : PN extends "IbcBridge"
+  ? IbcMessageId
+  : never;
 
 // Wormhole Message Identifier used to fetch a VAA
 // Possibly with a VAA already set

--- a/core/definitions/src/protocols/cctp.ts
+++ b/core/definitions/src/protocols/cctp.ts
@@ -115,7 +115,7 @@ export interface CircleBridge<
 > {
   redeem(
     sender: AccountAddress<C>,
-    message: string,
+    message: CircleMessage,
     attestation: string,
   ): AsyncGenerator<UnsignedTransaction<N, C>>;
   transfer(

--- a/core/definitions/src/protocols/cctp.ts
+++ b/core/definitions/src/protocols/cctp.ts
@@ -7,6 +7,7 @@ import {
   PlatformToChains,
   deserializeLayout,
   encoding,
+  serializeLayout,
 } from "@wormhole-foundation/sdk-base";
 import { AccountAddress, ChainAddress } from "../address";
 import { CircleMessageId } from "../attestation";
@@ -59,12 +60,17 @@ export const deserializeCircleMessage = (data: Uint8Array): [CircleMessage, stri
   return [msg, messsageHash];
 };
 
+export const serializeCircleMessage = (msg: CircleMessage): Uint8Array => {
+  return serializeLayout(circleMessageLayout, msg);
+};
+
 export type CircleTransferMessage = {
   from: ChainAddress;
   to: ChainAddress;
   token: TokenId;
   amount: bigint;
-  messageId: CircleMessageId;
+  message: CircleMessage;
+  id: CircleMessageId;
 };
 
 export type CircleTransferDetails = {

--- a/examples/src/tokenBridge.ts
+++ b/examples/src/tokenBridge.ts
@@ -49,7 +49,7 @@ import "@wormhole-foundation/connect-sdk-solana-tokenbridge";
   // of the token
   // On the destination side, a wrapped version of the token will be minted
   // to the address specified in the transfer VAA
-  const automatic = true;
+  const automatic = false;
 
   // The automatic relayer has the ability to deliver some native gas funds to the destination account
   // The amount specified for native gas will be swapped for the native gas token according

--- a/platforms/evm/protocols/cctp/src/circleBridge.ts
+++ b/platforms/evm/protocols/cctp/src/circleBridge.ts
@@ -3,6 +3,7 @@ import {
   ChainAddress,
   ChainsConfig,
   CircleBridge,
+  CircleMessage,
   CircleTransferMessage,
   Contracts,
   Network,
@@ -12,6 +13,7 @@ import {
   encoding,
   nativeChainAddress,
   nativeChainIds,
+  serializeCircleMessage,
 } from '@wormhole-foundation/connect-sdk';
 
 import { MessageTransmitter, TokenMessenger } from './ethers-contracts';
@@ -99,13 +101,13 @@ export class EvmCircleBridge<N extends Network, C extends EvmChains>
 
   async *redeem(
     sender: AccountAddress<C>,
-    message: string,
+    message: CircleMessage,
     attestation: string,
   ): AsyncGenerator<EvmUnsignedTransaction<N, C>> {
     const senderAddr = new EvmAddress(sender).toString();
 
     const txReq = await this.msgTransmitter.receiveMessage.populateTransaction(
-      encoding.hex.decode(message),
+      serializeCircleMessage(message),
       encoding.hex.decode(attestation),
     );
 

--- a/platforms/evm/protocols/cctp/src/circleBridge.ts
+++ b/platforms/evm/protocols/cctp/src/circleBridge.ts
@@ -209,7 +209,8 @@ export class EvmCircleBridge<N extends Network, C extends EvmChains>
       to: nativeChainAddress(rcvChain, xferReceiver),
       token: token,
       amount: body.amount,
-      messageId: { message, hash },
+      message: circleMsg,
+      id: { hash },
     };
   }
 

--- a/platforms/solana/protocols/cctp/src/circleBridge.ts
+++ b/platforms/solana/protocols/cctp/src/circleBridge.ts
@@ -187,7 +187,8 @@ export class SolanaCircleBridge<N extends Network, C extends SolanaChains>
       to: nativeChainAddress(rcvChain, xferReceiver),
       token: token,
       amount: body.amount,
-      messageId: { message: encoding.hex.encode(message), hash },
+      message: msg,
+      id: { hash },
     };
   }
 

--- a/platforms/solana/protocols/cctp/src/circleBridge.ts
+++ b/platforms/solana/protocols/cctp/src/circleBridge.ts
@@ -4,13 +4,13 @@ import {
   ChainAddress,
   ChainsConfig,
   CircleBridge,
+  CircleMessage,
   CircleTransferMessage,
   Contracts,
   Network,
   Platform,
   circle,
   deserializeCircleMessage,
-  encoding,
   nativeChainAddress,
 } from '@wormhole-foundation/connect-sdk';
 
@@ -88,7 +88,7 @@ export class SolanaCircleBridge<N extends Network, C extends SolanaChains>
 
   async *redeem(
     sender: AccountAddress<C>,
-    message: string,
+    message: CircleMessage,
     attestation: string,
   ): AsyncGenerator<SolanaUnsignedTransaction<N, C>> {
     const usdc = new PublicKey(
@@ -97,15 +97,10 @@ export class SolanaCircleBridge<N extends Network, C extends SolanaChains>
 
     const senderPk = new SolanaAddress(sender).unwrap();
 
-    const [circleMsg, _] = deserializeCircleMessage(
-      encoding.hex.decode(message),
-    );
-
     const ix = await createReceiveMessageInstruction(
       this.messageTransmitter.programId,
       this.tokenMessenger.programId,
       usdc,
-      circleMsg,
       message,
       attestation,
       senderPk,

--- a/platforms/solana/protocols/cctp/src/utils/instructions/receiveMessage.ts
+++ b/platforms/solana/protocols/cctp/src/utils/instructions/receiveMessage.ts
@@ -10,6 +10,7 @@ import {
   CircleMessage,
   circle,
   encoding,
+  serializeCircleMessage,
 } from '@wormhole-foundation/connect-sdk';
 import { findProgramAddress } from '../accounts';
 import { createMessageTransmitterProgramInterface } from '../program';
@@ -19,11 +20,10 @@ export async function createReceiveMessageInstruction(
   tokenMessengerProgramId: PublicKey,
   usdcAddress: PublicKey,
   circleMessage: CircleMessage,
-  message: string,
   attestation: CircleAttestation,
   payer?: PublicKeyInitData,
 ) {
-  const messageBytes = Buffer.from(encoding.hex.decode(message));
+  const messageBytes = Buffer.from(serializeCircleMessage(circleMessage));
   const attestationBytes = Buffer.from(encoding.hex.decode(attestation));
 
   const solanaUsdcAddress = new PublicKey(usdcAddress);


### PR DESCRIPTION
I _think_ it makes sense to pass the Payload type through to the VAA in the WormholeMessageId but its a little bit weird to strongly type the maybe-unknown field.

Note there are some conflicts according to typescript wrt the different specification of the same payload types that required an `as` cast. Could be me doing it wrong.

Also modified the TokenTransfer to remove the redundant nesting of the type.