### PR TITLE
Refactor Addresses

### DIFF
--- a/connect/src/protocols/cctpTransfer.ts
+++ b/connect/src/protocols/cctpTransfer.ts
@@ -17,7 +17,6 @@ import {
   isCircleTransferDetails,
   isTransactionIdentifier,
   isWormholeMessageId,
-  nativeChainAddress,
 } from "@wormhole-foundation/sdk-definitions";
 
 import { signSendWait } from "../common";
@@ -129,7 +128,7 @@ export class CircleTransfer<N extends Network = Network>
 
     let automatic = false;
     if (wormholeRelayer) {
-      const relayerAddress = nativeChainAddress(
+      const relayerAddress = Wormhole.chainAddress(
         chain,
         wormholeRelayer,
       ).address.toUniversalAddress();
@@ -137,8 +136,8 @@ export class CircleTransfer<N extends Network = Network>
     }
 
     const details: CircleTransferDetails = {
-      from: nativeChainAddress(from.chain, vaa.payload.caller),
-      to: nativeChainAddress(rcvChain, rcvAddress),
+      from: { chain: from.chain, address: vaa.payload.caller },
+      to: { chain: rcvChain, address: rcvAddress },
       amount: vaa.payload.token.amount,
       automatic,
     };
@@ -165,8 +164,8 @@ export class CircleTransfer<N extends Network = Network>
     const rcvChain = circle.toCircleChain(msg.destinationDomain);
 
     const details: CircleTransferDetails = {
-      from: nativeChainAddress(sendChain, xferSender),
-      to: nativeChainAddress(rcvChain, xferReceiver),
+      from: { chain: sendChain, address: xferSender },
+      to: { chain: rcvChain, address: xferReceiver },
       amount: burnMessage.amount,
       automatic: false,
     };

--- a/connect/src/protocols/gatewayTransfer.ts
+++ b/connect/src/protocols/gatewayTransfer.ts
@@ -4,8 +4,8 @@ import {
   chainToPlatform,
   encoding,
   toChain,
+  PlatformToChains,
 } from "@wormhole-foundation/sdk-base";
-import { PlatformToChains } from "@wormhole-foundation/sdk-base/src";
 import {
   ChainAddress,
   ChainContext,
@@ -25,7 +25,6 @@ import {
   isGatewayTransferDetails,
   isTransactionIdentifier,
   isWormholeMessageId,
-  nativeChainAddress,
   toGatewayMsg,
   toNative,
   AttestationId,
@@ -200,7 +199,7 @@ export class GatewayTransfer<N extends Network = Network> implements WormholeTra
         const recipientAddress = encoding.bytes.decode(
           encoding.b64.decode(maybeWithPayload.recipient),
         );
-        to = nativeChainAddress(destChain, recipientAddress);
+        to = Wormhole.chainAddress(destChain, recipientAddress);
       } catch {
         /*Ignoring, throws if not the payload isnt JSON*/
       }

--- a/connect/src/tasks.ts
+++ b/connect/src/tasks.ts
@@ -1,4 +1,4 @@
-import { Chain, Network, Platform } from "@wormhole-foundation/sdk-base";
+import { PlatformToChains, Chain, Network, Platform } from "@wormhole-foundation/sdk-base";
 import {
   GatewayTransferMsg,
   GatewayTransferWithPayloadMsg,
@@ -14,7 +14,6 @@ import {
   isTransactionIdentifier,
 } from "@wormhole-foundation/sdk-definitions";
 import { DEFAULT_TASK_TIMEOUT } from "./config";
-import { PlatformToChains } from "@wormhole-foundation/sdk-base/src";
 
 // A task is a retryable function, it should return a Thing or null for a failure case
 // It should throw on a permanent failure instead of retrying

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -5,6 +5,7 @@ import {
   PlatformToChains,
   chainToPlatform,
   circle,
+  ChainToPlatform,
 } from "@wormhole-foundation/sdk-base";
 import {
   ChainAddress,
@@ -22,10 +23,10 @@ import {
   deserialize,
   toNative,
 } from "@wormhole-foundation/sdk-definitions";
-import { WormholeConfig, CONFIG, DEFAULT_TASK_TIMEOUT } from "./config";
+import { getCircleAttestationWithRetry } from "./circle-api";
+import { CONFIG, DEFAULT_TASK_TIMEOUT, WormholeConfig } from "./config";
 import { CircleTransfer } from "./protocols/cctpTransfer";
 import { TokenTransfer } from "./protocols/tokenTransfer";
-import { getCircleAttestationWithRetry } from "./circle-api";
 import { retry } from "./tasks";
 import {
   TransactionStatus,
@@ -34,7 +35,6 @@ import {
   getVaaBytesWithRetry,
   getVaaWithRetry,
 } from "./whscan-api";
-import { ChainToPlatform } from "@wormhole-foundation/sdk-base/src";
 
 type PlatformMap<N extends Network, P extends Platform = Platform> = Map<P, PlatformContext<N, P>>;
 type ChainMap<N extends Network, C extends Chain = Chain> = Map<
@@ -356,7 +356,7 @@ export class Wormhole<N extends Network> {
    * @returns The ChainAddress
    */
   static chainAddress<C extends Chain>(chain: C, address: string): ChainAddress<C> {
-    return { chain, address: toNative(chain, address) };
+    return { chain, address: Wormhole.parseAddress(chain, address) };
   }
 
   /**

--- a/core/base/src/constants/index.ts
+++ b/core/base/src/constants/index.ts
@@ -18,6 +18,7 @@ export {
   isPlatform,
   platformToChains,
   chainToPlatform,
+  platformToAddressFormat,
 } from "./platforms";
 
 export * as platform from "./platforms";

--- a/core/definitions/__tests__/circleMessage.ts
+++ b/core/definitions/__tests__/circleMessage.ts
@@ -1,7 +1,6 @@
-import { deserializeLayout, circle, encoding } from "@wormhole-foundation/sdk-base";
+import { deserializeLayout, circle, encoding, contracts } from "@wormhole-foundation/sdk-base";
 import { circleMessageLayout } from "../src/protocols/cctp";
 import { UniversalAddress } from "../src";
-import { circleContracts } from "@wormhole-foundation/sdk-base/src/constants/contracts";
 
 const ethAddressToUniversal = (address: string) => {
   return new UniversalAddress("00".repeat(12) + address.slice(2));
@@ -18,20 +17,16 @@ describe("Circle Message tests", function () {
     const toChain = "Avalanche";
 
     // same sender and receiver
-    const accountSender = ethAddressToUniversal(
-      "0x6603b4a7e29dfbdb6159c395a915e74757c1fb13",
-    );
+    const accountSender = ethAddressToUniversal("0x6603b4a7e29dfbdb6159c395a915e74757c1fb13");
 
     const actualSender = ethAddressToUniversal(
-      circleContracts("Testnet", fromChain).tokenMessenger,
+      contracts.circleContracts("Testnet", fromChain).tokenMessenger,
     );
     const actualReceiver = ethAddressToUniversal(
-      circleContracts("Testnet", toChain).tokenMessenger,
+      contracts.circleContracts("Testnet", toChain).tokenMessenger,
     );
 
-    const tokenAddress = ethAddressToUniversal(
-      circle.usdcContract("Testnet", fromChain),
-    );
+    const tokenAddress = ethAddressToUniversal(circle.usdcContract("Testnet", fromChain));
 
     const decoded = deserializeLayout(circleMessageLayout, orig);
     expect(decoded.sourceDomain).toEqual(fromChain);

--- a/core/definitions/src/layout-items/circle.ts
+++ b/core/definitions/src/layout-items/circle.ts
@@ -1,6 +1,4 @@
-import { circle } from "@wormhole-foundation/sdk-base";
-import { UintLayoutItem } from "@wormhole-foundation/sdk-base/dist/cjs";
-import { CustomConversion } from "@wormhole-foundation/sdk-base/src";
+import { UintLayoutItem, CustomConversion, circle } from "@wormhole-foundation/sdk-base";
 
 export const circleDomainItem = {
   binary: "uint",

--- a/core/definitions/src/protocol.ts
+++ b/core/definitions/src/protocol.ts
@@ -28,7 +28,10 @@ export type ProtocolImplementation<
   : never;
 
 export interface ProtocolInitializer<P extends Platform, PN extends ProtocolName> {
-  fromRpc(rpc: RpcConnection<P>, config: ChainsConfig<Network, P>): ProtocolImplementation<P, PN>;
+  fromRpc(
+    rpc: RpcConnection<P>,
+    config: ChainsConfig<Network, P>,
+  ): Promise<ProtocolImplementation<P, PN>>;
 }
 
 const protocolFactory = new Map<
@@ -74,7 +77,7 @@ export function getProtocolInitializer<P extends Platform, PN extends ProtocolNa
   const pctr = protocols.get(protocol);
   if (!pctr) throw new Error(`No protocol registered for ${platform}:${protocol}`);
 
-  return pctr as ProtocolInitializer<P, PN>;
+  return pctr;
 }
 
 export const create = <N extends Network, P extends Platform, PN extends ProtocolName, T>(
@@ -84,5 +87,5 @@ export const create = <N extends Network, P extends Platform, PN extends Protoco
   config: ChainsConfig<N, P>,
 ): Promise<T> => {
   const pctr = getProtocolInitializer(platform, protocol);
-  return pctr.fromRpc(rpc, config) as Promise<T>;
+  return pctr.fromRpc(rpc, config);
 };

--- a/core/definitions/src/protocols/core.ts
+++ b/core/definitions/src/protocols/core.ts
@@ -1,10 +1,10 @@
-import { Network, Platform } from "@wormhole-foundation/sdk-base";
-import { PlatformToChains } from "@wormhole-foundation/sdk-base/src";
+import { PlatformToChains, Network, Platform } from "@wormhole-foundation/sdk-base";
 import { AccountAddress } from "../address";
 import { WormholeMessageId } from "../attestation";
 import { TxHash } from "../types";
 import { UnsignedTransaction } from "../unsignedTransaction";
 import { VAA } from "../vaa";
+
 export interface WormholeCore<
   N extends Network,
   P extends Platform,

--- a/core/definitions/src/protocols/ibc.ts
+++ b/core/definitions/src/protocols/ibc.ts
@@ -1,13 +1,12 @@
 import {
   Chain,
   ChainId,
-  ChainToPlatform,
   Network,
   Platform,
   PlatformToChains,
   encoding,
   toChain,
-  toChainId
+  toChainId,
 } from "@wormhole-foundation/sdk-base";
 import { AccountAddress, ChainAddress, NativeAddress, TokenAddress } from "../address";
 import { IbcMessageId, WormholeMessageId } from "../attestation";
@@ -51,33 +50,23 @@ export interface GatewayTransferWithPayloadMsg {
 // GatewayIBCTransferMsg is the message sent in the memo of an IBC transfer
 // to be decoded and executed by the Gateway contract.
 export interface GatewayIbcTransferMsg {
-  gateway_ibc_token_bridge_payload:
-  | GatewayTransferMsg
-  | GatewayTransferWithPayloadMsg;
+  gateway_ibc_token_bridge_payload: GatewayTransferMsg | GatewayTransferWithPayloadMsg;
 }
 
-export function isGatewayTransferMsg(
-  thing: GatewayTransferMsg | any,
-): thing is GatewayTransferMsg {
+export function isGatewayTransferMsg(thing: GatewayTransferMsg | any): thing is GatewayTransferMsg {
   return (<GatewayTransferMsg>thing).gateway_transfer !== undefined;
 }
 
 export function isGatewayTransferWithPayloadMsg(
   thing: GatewayTransferWithPayloadMsg | any,
 ): thing is GatewayTransferWithPayloadMsg {
-  return (
-    (<GatewayTransferWithPayloadMsg>thing).gateway_transfer_with_payload !==
-    undefined
-  );
+  return (<GatewayTransferWithPayloadMsg>thing).gateway_transfer_with_payload !== undefined;
 }
 
 export function isGatewayIbcTransferMsg(
   thing: GatewayIbcTransferMsg | any,
 ): thing is GatewayIbcTransferMsg {
-  return (
-    (<GatewayIbcTransferMsg>thing).gateway_ibc_token_bridge_payload !==
-    undefined
-  );
+  return (<GatewayIbcTransferMsg>thing).gateway_ibc_token_bridge_payload !== undefined;
 }
 
 export function isGatewayTransferDetails(
@@ -94,18 +83,13 @@ export function isGatewayTransferDetails(
 // Get the underlying payload from a gateway message
 // without prefix
 export function toGatewayMsg(
-  msg:
-    | GatewayTransferMsg
-    | GatewayTransferWithPayloadMsg
-    | GatewayIbcTransferMsg
-    | string,
+  msg: GatewayTransferMsg | GatewayTransferWithPayloadMsg | GatewayIbcTransferMsg | string,
 ): GatewayMsg {
   if (typeof msg === "string") msg = JSON.parse(msg);
 
   if (isGatewayIbcTransferMsg(msg)) msg = msg.gateway_ibc_token_bridge_payload;
   if (isGatewayTransferMsg(msg)) return msg.gateway_transfer;
-  if (isGatewayTransferWithPayloadMsg(msg))
-    return msg.gateway_transfer_with_payload;
+  if (isGatewayTransferWithPayloadMsg(msg)) return msg.gateway_transfer_with_payload;
 
   throw new Error(`Unrecognized payload: ${msg}`);
 }
@@ -115,9 +99,7 @@ export function gatewayTransferMsg(
 ): GatewayTransferMsg | GatewayTransferWithPayloadMsg {
   if (isGatewayTransferDetails(gtd)) {
     // If we've already got a payload, b64 encode it so it works in json
-    const _payload = gtd.payload
-      ? encoding.b64.encode(gtd.payload)
-      : undefined;
+    const _payload = gtd.payload ? encoding.b64.encode(gtd.payload) : undefined;
 
     // Encode the payload so the gateway contract knows where to forward the
     // newly minted tokens
@@ -143,7 +125,7 @@ export function gatewayTransferMsg(
 
 export function makeGatewayTransferMsg<CN extends Chain>(
   chain: CN,
-  recipient: NativeAddress<ChainToPlatform<CN>> | string,
+  recipient: NativeAddress<CN> | string,
   fee: bigint = 0n,
   nonce: number,
   payload?: string,
@@ -153,8 +135,8 @@ export function makeGatewayTransferMsg<CN extends Chain>(
   const address =
     typeof recipient === "string"
       ? recipient
-      // @ts-ignore
-      : encoding.b64.encode(recipient.toString());
+      : // @ts-ignore
+        encoding.b64.encode(recipient.toString());
 
   const common = {
     chain: toChainId(chain),
@@ -165,8 +147,8 @@ export function makeGatewayTransferMsg<CN extends Chain>(
 
   const msg: GatewayTransferWithPayloadMsg | GatewayTransferMsg = payload
     ? ({
-      gateway_transfer_with_payload: { ...common, payload: payload },
-    } as GatewayTransferWithPayloadMsg)
+        gateway_transfer_with_payload: { ...common, payload: payload },
+      } as GatewayTransferWithPayloadMsg)
     : ({ gateway_transfer: { ...common } } as GatewayTransferMsg);
 
   return msg;
@@ -181,9 +163,7 @@ export interface IbcTransferInfo {
   pending: boolean;
 }
 
-export function isIbcTransferInfo(
-  thing: IbcTransferInfo | any,
-): thing is IbcTransferInfo {
+export function isIbcTransferInfo(thing: IbcTransferInfo | any): thing is IbcTransferInfo {
   return (
     (<IbcTransferInfo>thing).id !== undefined &&
     (<IbcTransferInfo>thing).pending !== undefined &&
@@ -218,9 +198,7 @@ export interface IbcBridge<N extends Network, P extends Platform, C extends Plat
 
   // Find the wormhole emitted message id for a given IBC transfer
   // if it does not exist, this will return null
-  lookupMessageFromIbcMsgId(
-    msg: IbcMessageId,
-  ): Promise<WormholeMessageId | null>;
+  lookupMessageFromIbcMsgId(msg: IbcMessageId): Promise<WormholeMessageId | null>;
 
   // Get IbcTransferInfo
   // TODO: overload

--- a/core/definitions/src/relayer.ts
+++ b/core/definitions/src/relayer.ts
@@ -1,15 +1,19 @@
-import { Chain, Platform } from "@wormhole-foundation/sdk-base";
+import { Chain } from "@wormhole-foundation/sdk-base";
 import { TokenAddress } from "./address";
 
-export interface Relayer<P extends Platform> {
+export interface Relayer {
   relaySupported(chain: Chain): boolean;
-  getRelayerFee(sourceChain: Chain, destChain: Chain, tokenId: TokenAddress<P>): Promise<bigint>;
+  getRelayerFee(
+    sourceChain: Chain,
+    destChain: Chain,
+    tokenId: TokenAddress<Chain>,
+  ): Promise<bigint>;
   // TODO: What should this be named?
   // I don't think it should return an UnisgnedTransaction
   // rather it should take some signing callbacks and
   // a ref to track the progress
   startTransferWithRelay(
-    token: TokenAddress<P>,
+    token: TokenAddress<Chain>,
     amount: bigint,
     toNativeToken: string,
     sendingChain: Chain,
@@ -20,13 +24,13 @@ export interface Relayer<P extends Platform> {
   ): Promise<any>;
   calculateNativeTokenAmt(
     destChain: Chain,
-    tokenId: TokenAddress<P>,
+    tokenId: TokenAddress<Chain>,
     amount: bigint,
     walletAddress: string,
   ): Promise<bigint>;
   calculateMaxSwapAmount(
     destChain: Chain,
-    tokenId: TokenAddress<P>,
+    tokenId: TokenAddress<Chain>,
     walletAddress: string,
   ): Promise<bigint>;
 }

--- a/core/definitions/src/testing/mocks/tokenBridge.ts
+++ b/core/definitions/src/testing/mocks/tokenBridge.ts
@@ -1,4 +1,4 @@
-import { Network, Platform } from "@wormhole-foundation/sdk-base";
+import { PlatformToChains, Network, Platform } from "@wormhole-foundation/sdk-base";
 import {
   TokenAddress,
   ChainAddress,
@@ -7,7 +7,6 @@ import {
   TokenBridge,
   UnsignedTransaction,
 } from "../..";
-import { PlatformToChains } from "@wormhole-foundation/sdk-base/src";
 
 //export function mockTokenBridgeFactory(
 //  p: Platform,

--- a/core/definitions/src/testing/utils/address.ts
+++ b/core/definitions/src/testing/utils/address.ts
@@ -1,12 +1,11 @@
-import crypto from "crypto";
 import {
   Chain,
-  Platform,
   chainToPlatform,
   encoding,
   isPlatform,
   platformToChains,
 } from "@wormhole-foundation/sdk-base";
+import crypto from "crypto";
 import { ChainAddress, NativeAddress, UniversalAddress, toNative } from "../../";
 
 // return a random buffer of length n
@@ -57,7 +56,7 @@ export function makeUniversalAddress(chain: Chain): UniversalAddress {
   return new UniversalAddress("0x" + nativeAddress.padStart(64, "0"));
 }
 // make a random NativeAddress for a given chain
-export function makeNativeAddress<T extends Chain | Platform>(chain: T): NativeAddress<T> {
+export function makeNativeAddress<T extends Chain>(chain: T): NativeAddress<T> {
   let cn: Chain;
   if (isPlatform(chain)) {
     // just grab the first one

--- a/core/definitions/src/types.ts
+++ b/core/definitions/src/types.ts
@@ -14,11 +14,8 @@ import {
   rpc,
   toChainId,
 } from "@wormhole-foundation/sdk-base";
-import { ChainAddress, NativeAddress, toNative } from "./address";
+import { ChainAddress } from "./address";
 import { Contracts, getContracts } from "./contracts";
-import { Signer, isSigner } from "./signer";
-
-import { UniversalAddress } from "./universalAddress";
 
 export type TxHash = string;
 export type SequenceId = bigint;
@@ -36,45 +33,6 @@ export function isTokenId<C extends Chain>(thing: any): thing is TokenId<C> {
 export type Balances = {
   [key: string]: bigint | null;
 };
-
-export function nativeChainAddress<C extends Chain>(
-  chain: C,
-  address: UniversalAddress | Uint8Array | string,
-): ChainAddress<C>;
-
-export function nativeChainAddress<C extends Chain>(
-  s: Signer<Network, C> | TokenId<C> | C,
-  a?: UniversalAddress | Uint8Array | string,
-): ChainAddress<C> {
-  let chain: C;
-  let address: NativeAddress<C>;
-
-  // its a chain address
-  if (a) {
-    // We might be passed a universal address as a string
-    // First try to decode it as native, otherwise try
-    // to decode it as universal and convert it to native
-    chain = s as C;
-    try {
-      address = toNative(chain, a);
-    } catch {
-      address = UniversalAddress.instanceof(a)
-        ? a.toNative(chain)
-        : new UniversalAddress(a).toNative(chain);
-    }
-  } else if (isSigner(s)) {
-    chain = s.chain();
-    address = toNative(s.chain(), s.address());
-  } else if (isTokenId(s)) {
-    // otherwise TokenId
-    chain = s.chain;
-    address = s.address.toNative(s.chain) as NativeAddress<C>;
-  } else {
-    throw new Error("Invalid nativeChainAddress parameters");
-  }
-
-  return { chain, address };
-}
 
 // Fully qualifier Transaction ID
 export type TransactionId<C extends Chain = Chain> = { chain: C; txid: TxHash };

--- a/examples/src/cosmos.ts
+++ b/examples/src/cosmos.ts
@@ -1,11 +1,11 @@
 import {
+  Network,
   GatewayTransfer,
   GatewayTransferDetails,
   Platform,
   TokenId,
   Wormhole,
   normalizeAmount,
-  toNative,
 } from "@wormhole-foundation/connect-sdk";
 // Import the platform specific packages
 import { CosmwasmPlatform, CosmwasmPlatformType } from "@wormhole-foundation/connect-sdk-cosmwasm";
@@ -13,12 +13,11 @@ import { EvmPlatform } from "@wormhole-foundation/connect-sdk-evm";
 
 import { TransferStuff, getStuff } from "./helpers";
 
+import "@wormhole-foundation/connect-sdk-cosmwasm-core";
+import "@wormhole-foundation/connect-sdk-cosmwasm-ibc";
+import "@wormhole-foundation/connect-sdk-cosmwasm-tokenbridge";
 import "@wormhole-foundation/connect-sdk-evm-core";
 import "@wormhole-foundation/connect-sdk-evm-tokenbridge";
-import "@wormhole-foundation/connect-sdk-cosmwasm-core";
-import "@wormhole-foundation/connect-sdk-cosmwasm-tokenbridge";
-import "@wormhole-foundation/connect-sdk-cosmwasm-ibc";
-import { Network } from "@wormhole-foundation/sdk-base/src";
 
 // We're going to transfer into, around, and out of the Cosmos ecosystem
 // First on Avalanche, transparently through gateway and over IBC to Cosmoshub
@@ -73,7 +72,7 @@ import { Network } from "@wormhole-foundation/sdk-base/src";
 
   const { denom } = route1.ibcTransfers![0]!.data;
   // Lookup the Gateway representation of the wrappd token
-  const cosmosTokenAddress = toNative("Wormchain", denom);
+  const cosmosTokenAddress = Wormhole.parseAddress("Wormchain", denom);
   //console.log("Wrapped Token: ", cosmosTokenAddress.toString());
 
   // Transfer Gateway factory tokens over IBC through gateway to another Cosmos chain

--- a/examples/src/helpers/helpers.ts
+++ b/examples/src/helpers/helpers.ts
@@ -1,4 +1,5 @@
 import {
+  Network,
   ChainAddress,
   ChainContext,
   Platform,
@@ -11,12 +12,11 @@ import {
   api,
   tasks,
 } from "@wormhole-foundation/connect-sdk";
-import { getCosmwasmSigner } from "@wormhole-foundation/connect-sdk-cosmwasm/src/testing";
 
-//import { getCosmwasmSigner } from "@wormhole-foundation/connect-sdk-cosmwasm/src/testing";
+// Importing from src so we dont have to rebuild to see debug stuff in signer
+import { getCosmwasmSigner } from "@wormhole-foundation/connect-sdk-cosmwasm/src/testing";
 import { getEvmSigner } from "@wormhole-foundation/connect-sdk-evm/src/testing";
 import { getSolanaSigner } from "@wormhole-foundation/connect-sdk-solana/src/testing";
-import { Network } from "@wormhole-foundation/sdk-base/src";
 
 // read in from `.env`
 require("dotenv").config();

--- a/platforms/aptos/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/aptos/protocols/tokenBridge/src/tokenBridge.ts
@@ -109,7 +109,7 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
     return false;
   }
 
-  async getWrappedAsset(token: TokenId): Promise<NativeAddress<C>> {
+  async getWrappedAsset(token: TokenId) {
     const assetFullyQualifiedType = await this.getAssetFullyQualifiedType(token);
 
     // check to see if we can get origin info from asset address
@@ -119,7 +119,7 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
     );
 
     // if successful, we can just return the computed address
-    return toNative(this.chain, assetFullyQualifiedType);
+    return new AptosAddress(assetFullyQualifiedType);
   }
 
   async isTransferCompleted(
@@ -148,8 +148,8 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
     }
   }
 
-  async getWrappedNative(): Promise<NativeAddress<C>> {
-    return toNative(this.chain, APTOS_COIN);
+  async getWrappedNative() {
+    return new AptosAddress(APTOS_COIN);
   }
 
   async *createAttestation(
@@ -323,7 +323,7 @@ export class AptosTokenBridge<N extends Network, C extends AptosChains>
   ): string {
     const data = serializeForeignAddressSeeds({
       chain: tokenId.chain,
-      tokenBridgeAddress: toNative(chain, tokenBridgeAddress).toUniversalAddress(),
+      tokenBridgeAddress: new AptosAddress(tokenBridgeAddress).toUniversalAddress(),
       tokenId: tokenId.address.toUniversalAddress(),
     });
     return encoding.hex.encode(sha3_256(data), true);

--- a/platforms/aptos/src/address.ts
+++ b/platforms/aptos/src/address.ts
@@ -10,15 +10,6 @@ import { APTOS_SEPARATOR } from "./constants";
 import { AptosPlatform } from "./platform";
 import { AnyAptosAddress, isValidAptosType } from "./types";
 
-declare global {
-  namespace WormholeNamespace {
-    interface PlatformToNativeAddressMapping {
-      // @ts-ignore
-      Aptos: AptosAddress;
-    }
-  }
-}
-
 export const AptosZeroAddress = "0x";
 
 // Sometimes Aptos addresses will be trimmed of leading 0s
@@ -92,6 +83,15 @@ export class AptosAddress implements Address {
       return other.unwrap() === this.unwrap();
     } else {
       return this.toUniversalAddress().equals(other);
+    }
+  }
+}
+
+declare global {
+  namespace WormholeNamespace {
+    interface PlatformToNativeAddressMapping {
+      // @ts-ignore
+      Aptos: AptosAddress;
     }
   }
 }

--- a/platforms/aptos/src/types.ts
+++ b/platforms/aptos/src/types.ts
@@ -6,8 +6,7 @@ export const unusedArbiterFee = 0n;
 export const _platform: "Aptos" = "Aptos";
 export type AptosPlatformType = typeof _platform;
 export type AptosChains = PlatformToChains<AptosPlatformType>;
-
-export type UniversalOrAptos = UniversalOrNative<AptosPlatformType>;
+export type UniversalOrAptos = UniversalOrNative<AptosChains>;
 export type AnyAptosAddress = UniversalOrAptos | string | Uint8Array;
 
 export type CurrentCoinBalancesResponse = {

--- a/platforms/cosmwasm/protocols/core/src/index.ts
+++ b/platforms/cosmwasm/protocols/core/src/index.ts
@@ -1,4 +1,5 @@
 import { registerProtocol } from "@wormhole-foundation/connect-sdk";
+import { _platform } from "@wormhole-foundation/connect-sdk-cosmwasm";
 import { CosmwasmWormholeCore } from "./wormholeCore";
 
 declare global {
@@ -9,6 +10,6 @@ declare global {
   }
 }
 
-registerProtocol("Cosmwasm", "WormholeCore", CosmwasmWormholeCore);
+registerProtocol(_platform, "WormholeCore", CosmwasmWormholeCore);
 
 export * from "./wormholeCore";

--- a/platforms/cosmwasm/protocols/ibc/src/index.ts
+++ b/platforms/cosmwasm/protocols/ibc/src/index.ts
@@ -1,4 +1,5 @@
 import { registerProtocol } from "@wormhole-foundation/connect-sdk";
+import { _platform } from "@wormhole-foundation/connect-sdk-cosmwasm";
 import { CosmwasmIbcBridge } from "./ibc";
 
 declare global {
@@ -9,6 +10,6 @@ declare global {
   }
 }
 
-registerProtocol("Cosmwasm", "IbcBridge", CosmwasmIbcBridge);
+registerProtocol(_platform, "IbcBridge", CosmwasmIbcBridge);
 
 export * from "./ibc";

--- a/platforms/cosmwasm/protocols/tokenBridge/src/index.ts
+++ b/platforms/cosmwasm/protocols/tokenBridge/src/index.ts
@@ -1,4 +1,5 @@
 import { registerProtocol } from "@wormhole-foundation/connect-sdk";
+import { _platform } from "@wormhole-foundation/connect-sdk-cosmwasm";
 import { CosmwasmTokenBridge } from "./tokenBridge";
 
 declare global {
@@ -9,6 +10,6 @@ declare global {
   }
 }
 
-registerProtocol("Cosmwasm", "TokenBridge", CosmwasmTokenBridge);
+registerProtocol(_platform, "TokenBridge", CosmwasmTokenBridge);
 
 export * from "./tokenBridge";

--- a/platforms/cosmwasm/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/cosmwasm/protocols/tokenBridge/src/tokenBridge.ts
@@ -289,7 +289,7 @@ export class CosmwasmTokenBridge<N extends Network, C extends CosmwasmChains>
 
     const toTranslator =
       this.translator &&
-      toNative(this.chain, this.translator).toUniversalAddress().equals(vaa.payload.to.address);
+      new CosmwasmAddress(this.translator).toUniversalAddress().equals(vaa.payload.to.address);
 
     const msg = toTranslator
       ? buildExecuteMsg(senderAddress, this.translator!, {

--- a/platforms/cosmwasm/src/address.ts
+++ b/platforms/cosmwasm/src/address.ts
@@ -8,15 +8,6 @@ import {
 import { CosmwasmPlatform } from "./platform";
 import { AnyCosmwasmAddress, _platform } from "./types";
 
-declare global {
-  namespace WormholeNamespace {
-    interface PlatformToNativeAddressMapping {
-      // @ts-ignore
-      Cosmwasm: CosmwasmAddress;
-    }
-  }
-}
-
 /*
 Categories:
 
@@ -239,6 +230,15 @@ export class CosmwasmAddress implements Address {
       return this.toString() === other.toString();
     } else {
       return other.equals(this.toUniversalAddress());
+    }
+  }
+}
+
+declare global {
+  namespace WormholeNamespace {
+    interface PlatformToNativeAddressMapping {
+      // @ts-ignore
+      Cosmwasm: CosmwasmAddress;
     }
   }
 }

--- a/platforms/cosmwasm/src/gateway.ts
+++ b/platforms/cosmwasm/src/gateway.ts
@@ -34,7 +34,7 @@ export class Gateway<N extends Network> extends ChainContext<
   // for a given chain
   async getWrappedAsset(token: TokenId): Promise<CosmwasmAddress> {
     const tb = await this.getTokenBridge();
-    const wrappedAsset = await tb.getWrappedAsset(token);
+    const wrappedAsset = new CosmwasmAddress(await tb.getWrappedAsset(token));
 
     // Encode the original address to base58 and add it
     // to the factory address for cw20 style factory token address

--- a/platforms/cosmwasm/src/platform.ts
+++ b/platforms/cosmwasm/src/platform.ts
@@ -15,6 +15,7 @@ import {
   PlatformContext,
   SignedTx,
   TxHash,
+  Wormhole,
   decimals,
   nativeChainIds,
   networkPlatformConfigs,
@@ -24,12 +25,7 @@ import { CosmwasmChain } from "./chain";
 import { IbcChannels, chainToNativeDenoms, networkChainToChannels } from "./constants";
 import { CosmwasmChains, CosmwasmPlatformType, _platform } from "./types";
 
-import {
-  Balances,
-  TokenId,
-  chainToPlatform,
-  nativeChainAddress,
-} from "@wormhole-foundation/connect-sdk";
+import { Balances, TokenId, chainToPlatform } from "@wormhole-foundation/connect-sdk";
 import { CosmwasmAddress } from "./address";
 import { IBC_TRANSFER_PORT } from "./constants";
 import { AnyCosmwasmAddress } from "./types";
@@ -79,7 +75,7 @@ export class CosmwasmPlatform<N extends Network> extends PlatformContext<N, Cosm
 
   static nativeTokenId<C extends CosmwasmChains>(network: Network, chain: C): TokenId<C> {
     if (!this.isSupportedChain(chain)) throw new Error(`invalid chain for CosmWasm: ${chain}`);
-    return nativeChainAddress(chain, this.getNativeDenom(network, chain));
+    return Wormhole.chainAddress(chain, this.getNativeDenom(network, chain));
   }
 
   static isSupportedChain(chain: Chain): boolean {

--- a/platforms/cosmwasm/src/types.ts
+++ b/platforms/cosmwasm/src/types.ts
@@ -5,7 +5,7 @@ export const _platform: "Cosmwasm" = "Cosmwasm";
 export type CosmwasmPlatformType = typeof _platform;
 
 export type CosmwasmChains = PlatformToChains<CosmwasmPlatformType>;
-export type UniversalOrCosmwasm = UniversalOrNative<CosmwasmPlatformType>;
+export type UniversalOrCosmwasm = UniversalOrNative<CosmwasmChains>;
 export type AnyCosmwasmAddress = UniversalOrCosmwasm | string | Uint8Array;
 
 export interface WrappedRegistryResponse {

--- a/platforms/evm/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/evm/__tests__/integration/tokenBridge.test.ts
@@ -9,17 +9,13 @@ import {
   encoding,
   nativeChainIds,
   testing,
-  toNative
+  toNative,
 } from '@wormhole-foundation/connect-sdk';
 
 import '@wormhole-foundation/connect-sdk-evm-core';
 import '@wormhole-foundation/connect-sdk-evm-tokenbridge';
 
-import {
-  EvmChains,
-  EvmPlatform
-} from '../../src';
-
+import { EvmChains, EvmPlatform } from '../../src';
 
 import { describe, expect, test } from '@jest/globals';
 
@@ -95,22 +91,22 @@ const TOKEN_ADDRESSES = {
 };
 
 const bogusAddress = toNative(
-  'Evm',
+  'Ethereum',
   '0x0000c581f595b53c5cb19bd0b3f8da6c935e2ca0',
 );
 const realNativeAddress = toNative(
-  'Evm',
+  'Ethereum',
   TOKEN_ADDRESSES['Mainnet']['Ethereum']['wsteth'],
 );
 const realWrappedAddress = toNative(
-  'Evm',
+  'Ethereum',
   TOKEN_ADDRESSES['Mainnet']['Ethereum']['wavax'],
 );
 
 const chain = 'Ethereum';
 const destChain = 'Avalanche';
 
-const sender = toNative('Evm', new Uint8Array(20));
+const sender = toNative('Ethereum', new Uint8Array(20));
 const recipient: ChainAddress = {
   chain: destChain,
   address: new UniversalAddress(new Uint8Array(32)),
@@ -122,7 +118,7 @@ describe('TokenBridge Tests', () => {
 
   test('Create TokenBridge', async () => {
     const rpc = p.getRpc('Ethereum');
-    tb = await p.getProtocol("TokenBridge", rpc)
+    tb = await p.getProtocol('TokenBridge', rpc);
     expect(tb).toBeTruthy();
   });
 
@@ -228,10 +224,7 @@ describe('TokenBridge Tests', () => {
 
       const { transaction } = attestTx;
       expect(transaction.chainId).toEqual(
-        nativeChainIds.networkChainToNativeChainId.get(
-          network,
-          chain
-        ),
+        nativeChainIds.networkChainToNativeChainId.get(network, chain),
       );
     });
 
@@ -325,10 +318,7 @@ describe('TokenBridge Tests', () => {
           const { transaction: xferTransaction } = xferTx;
           expect(xferTransaction.to).toEqual(tbAddress.toString());
           expect(xferTransaction.chainId).toEqual(
-            nativeChainIds.networkChainToNativeChainId.get(
-              network,
-              chain
-            ),
+            nativeChainIds.networkChainToNativeChainId.get(network, chain),
           );
         });
       });

--- a/platforms/evm/protocols/cctp/src/automaticCircleBridge.ts
+++ b/platforms/evm/protocols/cctp/src/automaticCircleBridge.ts
@@ -18,6 +18,7 @@ import { CircleRelayer } from './ethers-contracts';
 import { ethers_contracts } from '.';
 
 import {
+  EvmAddress,
   EvmChains,
   EvmPlatform,
   EvmPlatformType,
@@ -92,7 +93,7 @@ export class EvmAutomaticCircleBridge<N extends Network, C extends EvmChains>
     amount: bigint,
     nativeGas?: bigint,
   ): AsyncGenerator<EvmUnsignedTransaction<N, C>> {
-    const senderAddr = sender.toNative(this.chain).toString();
+    const senderAddr = new EvmAddress(sender).toString();
     const recipientChainId = chainToChainId(recipient.chain);
     const recipientAddress = recipient.address
       .toUniversalAddress()

--- a/platforms/evm/protocols/cctp/src/circleBridge.ts
+++ b/platforms/evm/protocols/cctp/src/circleBridge.ts
@@ -11,7 +11,6 @@ import {
   circle,
   deserializeCircleMessage,
   encoding,
-  nativeChainAddress,
   nativeChainIds,
   serializeCircleMessage,
 } from '@wormhole-foundation/connect-sdk';
@@ -204,11 +203,11 @@ export class EvmCircleBridge<N extends Network, C extends EvmChains>
     const sendChain = circle.toCircleChain(circleMsg.sourceDomain);
     const rcvChain = circle.toCircleChain(circleMsg.destinationDomain);
 
-    const token = nativeChainAddress(sendChain, body.burnToken);
+    const token = { chain: sendChain, address: body.burnToken };
 
     return {
-      from: nativeChainAddress(sendChain, xferSender),
-      to: nativeChainAddress(rcvChain, xferReceiver),
+      from: { chain: sendChain, address: xferSender },
+      to: { chain: rcvChain, address: xferReceiver },
       token: token,
       amount: body.amount,
       message: circleMsg,

--- a/platforms/evm/protocols/cctp/src/index.ts
+++ b/platforms/evm/protocols/cctp/src/index.ts
@@ -1,4 +1,5 @@
 import { registerProtocol } from '@wormhole-foundation/connect-sdk';
+import { _platform } from '@wormhole-foundation/connect-sdk-evm';
 import { EvmCircleBridge } from './circleBridge';
 import { EvmAutomaticCircleBridge } from './automaticCircleBridge';
 
@@ -10,8 +11,8 @@ declare global {
   }
 }
 
-registerProtocol('Evm', 'CircleBridge', EvmCircleBridge);
-registerProtocol('Evm', 'AutomaticCircleBridge', EvmAutomaticCircleBridge);
+registerProtocol(_platform, 'CircleBridge', EvmCircleBridge);
+registerProtocol(_platform, 'AutomaticCircleBridge', EvmAutomaticCircleBridge);
 
 export * as ethers_contracts from './ethers-contracts';
 export * from './circleBridge';

--- a/platforms/evm/protocols/core/src/index.ts
+++ b/platforms/evm/protocols/core/src/index.ts
@@ -1,4 +1,5 @@
 import { registerProtocol } from '@wormhole-foundation/connect-sdk';
+import { _platform } from '@wormhole-foundation/connect-sdk-evm';
 import { EvmWormholeCore } from './wormholeCore';
 
 declare global {
@@ -9,7 +10,7 @@ declare global {
   }
 }
 
-registerProtocol('Evm', 'WormholeCore', EvmWormholeCore);
+registerProtocol(_platform, 'WormholeCore', EvmWormholeCore);
 
 export * as ethers_contracts from './ethers-contracts';
 export * from './wormholeCore';

--- a/platforms/evm/protocols/tokenBridge/src/automaticTokenBridge.ts
+++ b/platforms/evm/protocols/tokenBridge/src/automaticTokenBridge.ts
@@ -75,7 +75,7 @@ export class EvmAutomaticTokenBridge<N extends Network, C extends EvmChains>
     sender: AccountAddress<C>,
     vaa: TokenBridge.VAA<'TransferWithPayload'>,
   ): AsyncGenerator<EvmUnsignedTransaction<N, C>> {
-    const senderAddr = sender.toNative(this.chain).toString();
+    const senderAddr = new EvmAddress(sender).toString();
     const txReq =
       await this.tokenBridgeRelayer.completeTransferWithRelay.populateTransaction(
         serialize(vaa),
@@ -113,7 +113,7 @@ export class EvmAutomaticTokenBridge<N extends Network, C extends EvmChains>
     amount: bigint,
     nativeGas?: bigint,
   ): AsyncGenerator<EvmUnsignedTransaction<N, C>> {
-    const senderAddr = sender.toNative(this.chain).toString();
+    const senderAddr = new EvmAddress(sender).toString();
     const recipientChainId = toChainId(recipient.chain);
 
     const recipientAddress = recipient.address
@@ -138,7 +138,7 @@ export class EvmAutomaticTokenBridge<N extends Network, C extends EvmChains>
       );
     } else {
       //TODO check for ERC-2612 (permit) support on token?
-      const tokenAddr = token.toNative(this.chain).toString();
+      const tokenAddr = new EvmAddress(token).toString();
 
       const tokenContract = EvmPlatform.getTokenImplementation(
         this.provider,

--- a/platforms/evm/protocols/tokenBridge/src/index.ts
+++ b/platforms/evm/protocols/tokenBridge/src/index.ts
@@ -1,4 +1,5 @@
 import { registerProtocol } from '@wormhole-foundation/connect-sdk';
+import { _platform } from '@wormhole-foundation/connect-sdk-evm';
 import { EvmTokenBridge } from './tokenBridge';
 import { EvmAutomaticTokenBridge } from './automaticTokenBridge';
 
@@ -10,8 +11,8 @@ declare global {
   }
 }
 
-registerProtocol('Evm', 'TokenBridge', EvmTokenBridge);
-registerProtocol('Evm', 'AutomaticTokenBridge', EvmAutomaticTokenBridge);
+registerProtocol(_platform, 'TokenBridge', EvmTokenBridge);
+registerProtocol(_platform, 'AutomaticTokenBridge', EvmAutomaticTokenBridge);
 
 export * as ethers_contracts from './ethers-contracts';
 export * from './tokenBridge';

--- a/platforms/evm/src/address.ts
+++ b/platforms/evm/src/address.ts
@@ -97,4 +97,4 @@ declare global {
   }
 }
 
-registerNative('Evm', EvmAddress);
+registerNative(_platform, EvmAddress);

--- a/platforms/evm/src/platform.ts
+++ b/platforms/evm/src/platform.ts
@@ -7,10 +7,10 @@ import {
   SignedTx,
   TokenId,
   TxHash,
+  Wormhole,
   chainToPlatform,
   decimals,
   encoding,
-  nativeChainAddress,
   nativeChainIds,
   networkPlatformConfigs,
 } from '@wormhole-foundation/connect-sdk';
@@ -56,7 +56,7 @@ export class EvmPlatform<N extends Network> extends PlatformContext<
   ): TokenId<C> {
     if (!EvmPlatform.isSupportedChain(chain))
       throw new Error(`invalid chain for EVM: ${chain}`);
-    return nativeChainAddress(chain, EvmZeroAddress);
+    return Wormhole.chainAddress(chain, EvmZeroAddress);
   }
 
   static isNativeTokenId<N extends Network, C extends EvmChains>(

--- a/platforms/evm/src/types.ts
+++ b/platforms/evm/src/types.ts
@@ -12,7 +12,7 @@ export const _platform: 'Evm' = 'Evm';
 export type EvmPlatformType = typeof _platform;
 
 export type EvmChains = PlatformToChains<EvmPlatformType>;
-export type UniversalOrEvm = UniversalOrNative<EvmPlatformType>;
+export type UniversalOrEvm = UniversalOrNative<EvmChains>;
 export type AnyEvmAddress = UniversalOrEvm | string | Uint8Array;
 
 export const addFrom = (txReq: TransactionRequest, from: string) => ({

--- a/platforms/solana/protocols/cctp/src/circleBridge.ts
+++ b/platforms/solana/protocols/cctp/src/circleBridge.ts
@@ -11,7 +11,6 @@ import {
   Platform,
   circle,
   deserializeCircleMessage,
-  nativeChainAddress,
 } from '@wormhole-foundation/connect-sdk';
 
 import { EventParser, Program } from '@project-serum/anchor';
@@ -175,11 +174,11 @@ export class SolanaCircleBridge<N extends Network, C extends SolanaChains>
     const sendChain = circle.toCircleChain(msg.sourceDomain);
     const rcvChain = circle.toCircleChain(msg.destinationDomain);
 
-    const token = nativeChainAddress(sendChain, body.burnToken);
+    const token = { chain: sendChain, address: body.burnToken };
 
     return {
-      from: nativeChainAddress(sendChain, xferSender),
-      to: nativeChainAddress(rcvChain, xferReceiver),
+      from: { chain: sendChain, address: xferSender },
+      to: { chain: rcvChain, address: xferReceiver },
       token: token,
       amount: body.amount,
       message: msg,

--- a/platforms/solana/protocols/cctp/src/index.ts
+++ b/platforms/solana/protocols/cctp/src/index.ts
@@ -1,5 +1,6 @@
 import { registerProtocol } from '@wormhole-foundation/connect-sdk';
 import { SolanaCircleBridge } from './circleBridge';
+import { _platform } from '@wormhole-foundation/connect-sdk-solana';
 
 declare global {
   namespace WormholeNamespace {
@@ -9,7 +10,7 @@ declare global {
   }
 }
 
-registerProtocol('Solana', 'CircleBridge', SolanaCircleBridge);
+registerProtocol(_platform, 'CircleBridge', SolanaCircleBridge);
 
 import { TokenMessenger, TokenMessengerIdl } from './anchor-idl/tokenMessenger';
 import {

--- a/platforms/solana/protocols/cctp/src/utils/instructions/receiveMessage.ts
+++ b/platforms/solana/protocols/cctp/src/utils/instructions/receiveMessage.ts
@@ -12,6 +12,7 @@ import {
   encoding,
   serializeCircleMessage,
 } from '@wormhole-foundation/connect-sdk';
+import { SolanaAddress } from '@wormhole-foundation/connect-sdk-solana';
 import { findProgramAddress } from '../accounts';
 import { createMessageTransmitterProgramInterface } from '../program';
 
@@ -32,9 +33,9 @@ export async function createReceiveMessageInstruction(
     circleMessage.payload.burnToken.toUint8Array(),
   );
 
-  const receiver = circleMessage.payload.mintRecipient
-    .toNative('Solana')
-    .unwrap() as PublicKey;
+  const receiver = new SolanaAddress(
+    circleMessage.payload.mintRecipient,
+  ).unwrap();
 
   const payerPubkey = payer ? new PublicKey(payer) : receiver;
 

--- a/platforms/solana/protocols/core/src/core.ts
+++ b/platforms/solana/protocols/core/src/core.ts
@@ -9,6 +9,14 @@ import {
   VersionedTransactionResponse,
 } from '@solana/web3.js';
 import {
+  SolanaAddress,
+  AnySolanaAddress,
+  SolanaChains,
+  SolanaPlatform,
+  SolanaPlatformType,
+  SolanaUnsignedTransaction,
+} from '@wormhole-foundation/connect-sdk-solana';
+import {
   ChainId,
   ChainsConfig,
   Contracts,
@@ -19,16 +27,7 @@ import {
   WormholeCore,
   WormholeMessageId,
   toChainId,
-  toNative,
 } from '@wormhole-foundation/connect-sdk';
-import {
-  AnySolanaAddress,
-  SolanaAddress,
-  SolanaChains,
-  SolanaPlatform,
-  SolanaPlatformType,
-  SolanaUnsignedTransaction,
-} from '@wormhole-foundation/connect-sdk-solana';
 import { Wormhole as WormholeCoreContract } from './types';
 import {
   createPostMessageInstruction,
@@ -72,7 +71,7 @@ export class SolanaWormholeCore<N extends Network, C extends SolanaChains>
   static async fromRpc<N extends Network>(
     connection: Connection,
     config: ChainsConfig<N, Platform>,
-  ): Promise<SolanaWormholeCore<N, SolanaChains>> {
+  ) {
     const [network, chain] = await SolanaPlatform.chainFromRpc(connection);
     const conf = config[chain]!;
     if (conf.network !== network)
@@ -296,7 +295,7 @@ export class SolanaWormholeCore<N extends Network, C extends SolanaChains>
       const sequence = acctInfo!.data.readBigUInt64LE(49);
 
       const emitterAddr = new Uint8Array(acctInfo!.data.subarray(59, 91));
-      const emitter = toNative(this.chain, emitterAddr);
+      const emitter = new SolanaAddress(emitterAddr);
 
       return {
         chain: this.chain,

--- a/platforms/solana/protocols/core/src/index.ts
+++ b/platforms/solana/protocols/core/src/index.ts
@@ -1,3 +1,4 @@
+import { _platform } from '@wormhole-foundation/connect-sdk-solana';
 import { registerProtocol } from '@wormhole-foundation/connect-sdk';
 import { SolanaWormholeCore } from './core';
 
@@ -9,7 +10,7 @@ declare global {
   }
 }
 
-registerProtocol('Solana', 'WormholeCore', SolanaWormholeCore);
+registerProtocol(_platform, 'WormholeCore', SolanaWormholeCore);
 
 export * from './core';
 export * from './types';

--- a/platforms/solana/protocols/core/src/utils/instructions/governance.ts
+++ b/platforms/solana/protocols/core/src/utils/instructions/governance.ts
@@ -17,7 +17,7 @@ import {
   derivePostedVaaKey,
   deriveUpgradeAuthorityKey,
 } from '../accounts';
-import { utils } from '@wormhole-foundation/connect-sdk-solana';
+import { SolanaAddress, utils } from '@wormhole-foundation/connect-sdk-solana';
 
 export function createSetFeesInstruction(
   connection: Connection,
@@ -244,7 +244,7 @@ export function getUpgradeContractAccounts(
     ),
     upgradeAuthority: deriveUpgradeAuthorityKey(wormholeProgramId),
     spill: new PublicKey(spill === undefined ? payer : spill),
-    implementation: newContract.toNative('Solana').unwrap(),
+    implementation: new SolanaAddress(newContract).unwrap(),
     programData: utils.deriveUpgradeableProgramKey(wormholeProgramId),
     wormholeProgram: new PublicKey(wormholeProgramId),
     rent: SYSVAR_RENT_PUBKEY,

--- a/platforms/solana/protocols/tokenBridge/src/automaticTokenBridge.ts
+++ b/platforms/solana/protocols/tokenBridge/src/automaticTokenBridge.ts
@@ -6,7 +6,6 @@ import {
   ChainId,
   ChainsConfig,
   Contracts,
-  NativeAddress,
   Network,
   TokenAddress,
   VAA,
@@ -112,7 +111,7 @@ export class SolanaAutomaticTokenBridge<
     nativeGas?: bigint | undefined,
   ) {
     const nonce = 0;
-    const senderAddress = sender.toNative(this.chain).unwrap();
+    const senderAddress = new SolanaAddress(sender).unwrap();
     const recipientAddress = recipient.address
       .toUniversalAddress()
       .toUint8Array();
@@ -201,7 +200,7 @@ export class SolanaAutomaticTokenBridge<
     const tokenAddress =
       token === 'native'
         ? new PublicKey(NATIVE_MINT)
-        : token.toNative(this.chain).unwrap();
+        : new SolanaAddress(token).unwrap();
 
     const [{ fee }, { swapRate }, { relayerFeePrecision }] = await Promise.all([
       this.getForeignContract(recipient.chain),
@@ -225,7 +224,7 @@ export class SolanaAutomaticTokenBridge<
     const mint =
       token === 'native'
         ? new PublicKey(NATIVE_MINT)
-        : token.toNative(this.chain).unwrap();
+        : new SolanaAddress(token).unwrap();
 
     const [{ swapRate, maxNativeSwapAmount }, { swapRate: solSwapRate }] =
       await Promise.all([
@@ -262,7 +261,7 @@ export class SolanaAutomaticTokenBridge<
     const mint =
       token === 'native'
         ? new PublicKey(NATIVE_MINT)
-        : token.toNative(this.chain).unwrap();
+        : new SolanaAddress(token).unwrap();
 
     const decimals = Number(
       await SolanaPlatform.getDecimals(this.chain, this.connection, token),
@@ -289,7 +288,7 @@ export class SolanaAutomaticTokenBridge<
     const mint =
       token === 'native'
         ? new PublicKey(NATIVE_MINT)
-        : token.toNative(this.chain).unwrap();
+        : new SolanaAddress(token).unwrap();
 
     try {
       await this.getRegisteredToken(mint);
@@ -303,7 +302,7 @@ export class SolanaAutomaticTokenBridge<
     }
   }
 
-  async getRegisteredTokens(): Promise<NativeAddress<C>[]> {
+  async getRegisteredTokens() {
     return registeredTokens[this.network].map((addr) =>
       toNative(this.chain, addr),
     );

--- a/platforms/solana/protocols/tokenBridge/src/index.ts
+++ b/platforms/solana/protocols/tokenBridge/src/index.ts
@@ -1,3 +1,4 @@
+import { _platform } from '@wormhole-foundation/connect-sdk-solana';
 import { registerProtocol } from '@wormhole-foundation/connect-sdk';
 import { SolanaTokenBridge } from './tokenBridge';
 import { SolanaAutomaticTokenBridge } from './automaticTokenBridge';
@@ -10,8 +11,8 @@ declare global {
   }
 }
 
-registerProtocol('Solana', 'TokenBridge', SolanaTokenBridge);
-registerProtocol('Solana', 'AutomaticTokenBridge', SolanaAutomaticTokenBridge);
+registerProtocol(_platform, 'TokenBridge', SolanaTokenBridge);
+registerProtocol(_platform, 'AutomaticTokenBridge', SolanaAutomaticTokenBridge);
 
 export * from './tokenBridgeType';
 export * from './automaticTokenBridgeType';

--- a/platforms/solana/protocols/tokenBridge/src/utils/tokenBridge/accounts/endpoint.ts
+++ b/platforms/solana/protocols/tokenBridge/src/utils/tokenBridge/accounts/endpoint.ts
@@ -1,16 +1,15 @@
 import {
+  Commitment,
   Connection,
   PublicKey,
-  Commitment,
   PublicKeyInitData,
 } from '@solana/web3.js';
-import { utils } from '@wormhole-foundation/connect-sdk-solana';
 import {
   ChainId,
+  UniversalAddress,
   toChainId,
-  toChain,
-  toNative,
 } from '@wormhole-foundation/connect-sdk';
+import { utils } from '@wormhole-foundation/connect-sdk-solana';
 
 export function deriveEndpointKey(
   tokenBridgeProgramId: PublicKeyInitData,
@@ -24,7 +23,7 @@ export function deriveEndpointKey(
   }
   const emitterAddr =
     typeof emitterAddress === 'string'
-      ? toNative(toChain(emitterChain), emitterAddress).toUint8Array()
+      ? new UniversalAddress(emitterAddress).toUint8Array()
       : emitterAddress;
 
   return utils.deriveAddress(

--- a/platforms/solana/protocols/tokenBridge/src/utils/tokenBridge/accounts/wrapped.ts
+++ b/platforms/solana/protocols/tokenBridge/src/utils/tokenBridge/accounts/wrapped.ts
@@ -1,31 +1,23 @@
 import {
+  Commitment,
   Connection,
   PublicKey,
-  Commitment,
   PublicKeyInitData,
 } from '@solana/web3.js';
+import { ChainId, toChainId } from '@wormhole-foundation/connect-sdk';
 import { utils } from '@wormhole-foundation/connect-sdk-solana';
-import {
-  ChainId,
-  toChainId,
-  toChain,
-  toNative,
-} from '@wormhole-foundation/connect-sdk';
 
 export function deriveWrappedMintKey(
   tokenBridgeProgramId: PublicKeyInitData,
   tokenChain: number | ChainId,
-  tokenAddress: Buffer | Uint8Array | string,
+  tokenAddress: Buffer | Uint8Array,
 ): PublicKey {
   if (tokenChain == toChainId('Solana')) {
     throw new Error(
       'tokenChain == CHAIN_ID_SOLANA does not have wrapped mint key',
     );
   }
-  if (typeof tokenAddress == 'string') {
-    const parsedAddress = toNative(toChain(tokenChain), tokenAddress);
-    tokenAddress = parsedAddress.toUint8Array();
-  }
+
   return utils.deriveAddress(
     [
       Buffer.from('wrapped'),

--- a/platforms/solana/src/address.ts
+++ b/platforms/solana/src/address.ts
@@ -9,15 +9,6 @@ import {
 import { PublicKey } from '@solana/web3.js';
 import { AnySolanaAddress, _platform } from './types';
 
-declare global {
-  namespace WormholeNamespace {
-    interface PlatformToNativeAddressMapping {
-      // @ts-ignore
-      Solana: SolanaAddress;
-    }
-  }
-}
-
 export const SolanaZeroAddress = '11111111111111111111111111111111';
 
 export class SolanaAddress implements Address {
@@ -70,4 +61,15 @@ export class SolanaAddress implements Address {
   }
 }
 
-registerNative('Solana', SolanaAddress);
+// This is required to make `type Z = NativeAddress<"Solana">;` resolve to SolanaAddress
+// but outside this module it does _not_ resolve correctly
+declare global {
+  namespace WormholeNamespace {
+    export interface PlatformToNativeAddressMapping {
+      // @ts-ignore
+      Solana: SolanaAddress;
+    }
+  }
+}
+
+registerNative(_platform, SolanaAddress);

--- a/platforms/solana/src/chain.ts
+++ b/platforms/solana/src/chain.ts
@@ -17,7 +17,7 @@ export class SolanaChain<
     address: UniversalOrNative<C>,
     token: UniversalOrNative<C>,
   ): Promise<ChainAddress<C>> {
-    const mint = token.toNative(this.chain).unwrap();
+    const mint = new SolanaAddress(token).unwrap();
     const owner = new SolanaAddress(address).unwrap();
 
     const ata = await getAssociatedTokenAddress(mint, owner);

--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -7,9 +7,9 @@ import {
   SignedTx,
   TokenId,
   TxHash,
+  Wormhole,
   chainToPlatform,
   decimals,
-  nativeChainAddress,
   nativeChainIds,
   networkPlatformConfigs,
 } from '@wormhole-foundation/connect-sdk';
@@ -70,7 +70,7 @@ export class SolanaPlatform<N extends Network> extends PlatformContext<
   ): TokenId<C> {
     if (!SolanaPlatform.isSupportedChain(chain))
       throw new Error(`invalid chain: ${chain}`);
-    return nativeChainAddress(chain, SolanaZeroAddress);
+    return Wormhole.chainAddress(chain, SolanaZeroAddress);
   }
 
   static isNativeTokenId<N extends Network, C extends SolanaChains>(

--- a/platforms/solana/src/types.ts
+++ b/platforms/solana/src/types.ts
@@ -1,8 +1,8 @@
+import { PublicKeyInitData } from '@solana/web3.js';
 import {
   PlatformToChains,
   UniversalOrNative,
 } from '@wormhole-foundation/connect-sdk';
-import { PublicKeyInitData } from '@solana/web3.js';
 
 export const unusedNonce = 0;
 export const unusedArbiterFee = 0n;
@@ -11,5 +11,5 @@ export const _platform: 'Solana' = 'Solana';
 export type SolanaPlatformType = typeof _platform;
 
 export type SolanaChains = PlatformToChains<SolanaPlatformType>;
-export type UniversalOrSolana = UniversalOrNative<SolanaPlatformType>;
+export type UniversalOrSolana = UniversalOrNative<SolanaChains>;
 export type AnySolanaAddress = UniversalOrSolana | PublicKeyInitData;

--- a/tokenRegistry/src/scripts/foreignAssets.ts
+++ b/tokenRegistry/src/scripts/foreignAssets.ts
@@ -43,10 +43,7 @@ export const isSupportedChain = (chain: Chain) => {
 
 export const createTokenId = (chain: Chain, address: string) => {
   if (!isSupportedChain(chain)) return undefined;
-  return {
-    chain,
-    address: toNative(chain, address),
-  };
+  return Wormhole.chainAddress(chain, address);
 };
 
 export const getForeignAddress = async (wh: Wormhole<Network>, chain: Chain, tokenId: TokenId) => {


### PR DESCRIPTION
A constant source of confusion is the `Address`/`UniversalAddress`/`NativeAddress<C>` types.

This PR removes the option of passing a `Platform` as the generic type parameter to help with debugging.

It also removes the `nativeChainAddress` method in favor of the static Wormhole class method to parse addresses or create a `ChainAddress`