### PR TITLE
Solana: Provide ability to resign transactions with ephemeral keys

### DIFF
--- a/examples/src/helpers/helpers.ts
+++ b/examples/src/helpers/helpers.ts
@@ -18,7 +18,7 @@ import {
 import { getAlgorandSigner } from "@wormhole-foundation/connect-sdk-algorand/src/testing";
 import { getCosmwasmSigner } from "@wormhole-foundation/connect-sdk-cosmwasm/src/testing";
 import { getEvmSigner } from "@wormhole-foundation/connect-sdk-evm/src/testing";
-import { getSolanaSigner } from "@wormhole-foundation/connect-sdk-solana/src/testing";
+import { getSolanaSignAndSendSigner } from "@wormhole-foundation/connect-sdk-solana/src/testing";
 
 // Use .env.example as a template for your .env file and populate it with secrets
 // for funded accounts on the relevant chain+network combos to run the example
@@ -56,7 +56,7 @@ export async function getStuff<
   const platform = chain.platform.utils()._platform;
   switch (platform) {
     case "Solana":
-      signer = await getSolanaSigner(await chain.getRpc(), getEnv("SOL_PRIVATE_KEY"));
+      signer = await getSolanaSignAndSendSigner(await chain.getRpc(), getEnv("SOL_PRIVATE_KEY"));
       break;
     case "Cosmwasm":
       signer = await getCosmwasmSigner(await chain.getRpc(), getEnv("COSMOS_MNEMONIC"));

--- a/platforms/solana/__tests__/integration/tokenBridge.test.ts
+++ b/platforms/solana/__tests__/integration/tokenBridge.test.ts
@@ -204,7 +204,7 @@ describe('TokenBridge Tests', () => {
       expect(attestTx.chain).toEqual(chain);
 
       const { transaction } = attestTx;
-      expect(transaction.instructions).toHaveLength(2);
+      expect(transaction.transaction.instructions).toHaveLength(2);
     });
 
     test('Submit Attestation', async () => {
@@ -229,7 +229,7 @@ describe('TokenBridge Tests', () => {
       });
       const submitAttestation = tb.submitAttestation(vaa, sender);
 
-      const allTxns = [];
+      const allTxns: SolanaUnsignedTransaction<TNet>[] = [];
       for await (const atx of submitAttestation) {
         allTxns.push(atx);
       }
@@ -237,9 +237,9 @@ describe('TokenBridge Tests', () => {
 
       const [verifySig, postVaa, create] = allTxns;
       //
-      expect(verifySig.transaction.instructions).toHaveLength(2);
-      expect(postVaa.transaction.instructions).toHaveLength(1);
-      expect(create.transaction.instructions).toHaveLength(1);
+      expect(verifySig.transaction.transaction.instructions).toHaveLength(2);
+      expect(postVaa.transaction.transaction.instructions).toHaveLength(1);
+      expect(create.transaction.transaction.instructions).toHaveLength(1);
     });
   });
 
@@ -260,7 +260,7 @@ describe('TokenBridge Tests', () => {
           const xfer = tb.transfer(sender, recipient, token, amount, payload);
           expect(xfer).toBeTruthy();
 
-          const allTxns = [];
+          const allTxns: SolanaUnsignedTransaction<TNet>[] = [];
           for await (const tx of xfer) {
             allTxns.push(tx);
           }
@@ -271,7 +271,7 @@ describe('TokenBridge Tests', () => {
           expect(xferTx!.chain).toEqual(chain);
 
           const { transaction } = xferTx;
-          expect(transaction.instructions).toHaveLength(6);
+          expect(transaction.transaction.instructions).toHaveLength(6);
           // ...
         });
 
@@ -285,7 +285,7 @@ describe('TokenBridge Tests', () => {
           );
           expect(xfer).toBeTruthy();
 
-          const allTxns = [];
+          const allTxns: SolanaUnsignedTransaction<TNet>[] = [];
           for await (const tx of xfer) {
             allTxns.push(tx);
           }
@@ -296,7 +296,7 @@ describe('TokenBridge Tests', () => {
           expect(xferTx.chain).toEqual(chain);
 
           const { transaction } = xferTx;
-          expect(transaction.instructions).toHaveLength(2);
+          expect(transaction.transaction.instructions).toHaveLength(2);
         });
       });
     });

--- a/platforms/solana/protocols/cctp/src/circleBridge.ts
+++ b/platforms/solana/protocols/cctp/src/circleBridge.ts
@@ -18,6 +18,7 @@ import {
   SolanaChains,
   SolanaPlatform,
   SolanaPlatformType,
+  SolanaTransaction,
   SolanaUnsignedTransaction,
 } from '@wormhole-foundation/connect-sdk-solana';
 import { MessageTransmitter, TokenMessenger } from '.';
@@ -105,13 +106,10 @@ export class SolanaCircleBridge<N extends Network, C extends SolanaChains>
       senderPk,
     );
 
-    const { blockhash } = await SolanaPlatform.latestBlock(this.connection);
     const transaction = new Transaction();
-    transaction.recentBlockhash = blockhash;
     transaction.feePayer = senderPk;
     transaction.add(ix);
-
-    yield this.createUnsignedTx(transaction, 'CircleBridge.Redeem');
+    yield this.createUnsignedTx({ transaction }, 'CircleBridge.Redeem');
   }
 
   async *transfer(
@@ -140,13 +138,11 @@ export class SolanaCircleBridge<N extends Network, C extends SolanaChains>
       amount,
     );
 
-    const { blockhash } = await SolanaPlatform.latestBlock(this.connection);
     const transaction = new Transaction();
-    transaction.recentBlockhash = blockhash;
     transaction.feePayer = senderPk;
     transaction.add(ix);
 
-    yield this.createUnsignedTx(transaction, 'CircleBridge.Transfer');
+    yield this.createUnsignedTx({ transaction }, 'CircleBridge.Transfer');
   }
 
   async isTransferCompleted(message: CircleBridge.Message): Promise<boolean> {
@@ -216,7 +212,7 @@ export class SolanaCircleBridge<N extends Network, C extends SolanaChains>
   }
 
   private createUnsignedTx(
-    txReq: Transaction,
+    txReq: SolanaTransaction,
     description: string,
     parallelizable: boolean = false,
   ): SolanaUnsignedTransaction<N, C> {

--- a/platforms/solana/protocols/core/src/core.ts
+++ b/platforms/solana/protocols/core/src/core.ts
@@ -36,8 +36,10 @@ import {
   createPostVaaInstruction,
   createReadOnlyWormholeProgramInterface,
   createVerifySignaturesInstructions,
+  createBridgeFeeTransferInstruction,
   derivePostedVaaKey,
   getWormholeBridgeData,
+  BridgeData,
 } from './utils';
 
 const SOLANA_SEQ_LOG = 'Program log: Sequence: ';
@@ -82,6 +84,7 @@ export class SolanaWormholeCore<N extends Network, C extends SolanaChains>
       throw new Error(
         `Network mismatch for chain ${chain}: ${conf.network} != ${network}`,
       );
+
     return new SolanaWormholeCore(
       network as N,
       chain,

--- a/platforms/solana/protocols/core/src/core.ts
+++ b/platforms/solana/protocols/core/src/core.ts
@@ -31,8 +31,6 @@ import {
 } from '@wormhole-foundation/connect-sdk';
 import { Wormhole as WormholeCoreContract } from './types';
 import {
-  BridgeData,
-  createBridgeFeeTransferInstruction,
   createPostMessageInstruction,
   createPostVaaInstruction,
   createReadOnlyWormholeProgramInterface,

--- a/platforms/solana/protocols/core/src/core.ts
+++ b/platforms/solana/protocols/core/src/core.ts
@@ -15,6 +15,7 @@ import {
   SolanaPlatform,
   SolanaPlatformType,
   SolanaUnsignedTransaction,
+  SolanaTransaction,
 } from '@wormhole-foundation/connect-sdk-solana';
 import {
   ChainId,
@@ -129,24 +130,20 @@ export class SolanaWormholeCore<N extends Network, C extends SolanaChains>
       fee,
     );
 
-    const { blockhash } = await SolanaPlatform.latestBlock(this.connection);
     const transaction = new Transaction();
-    transaction.recentBlockhash = blockhash;
     transaction.feePayer = payer;
     transaction.add(feeTransferIx, postMsgIx);
-    transaction.partialSign(messageAccount);
-
-    yield this.createUnsignedTx(transaction, 'Core.PublishMessage');
+    yield this.createUnsignedTx(
+      { transaction, signers: [messageAccount] },
+      'Core.PublishMessage',
+    );
   }
 
   async *verifyMessage(sender: AnySolanaAddress, vaa: VAA) {
     yield* this.postVaa(sender, vaa);
   }
 
-  async *postVaa(sender: AnySolanaAddress, vaa: VAA, blockhash?: string) {
-    if (!blockhash)
-      ({ blockhash } = await SolanaPlatform.latestBlock(this.connection));
-
+  async *postVaa(sender: AnySolanaAddress, vaa: VAA) {
     const postedVaaAddress = derivePostedVaaKey(
       this.coreBridge.programId,
       Buffer.from(vaa.hash),
@@ -173,11 +170,12 @@ export class SolanaWormholeCore<N extends Network, C extends SolanaChains>
       const verifySigTx = new Transaction().add(
         ...verifySignaturesInstructions.slice(i, i + 2),
       );
-      verifySigTx.recentBlockhash = blockhash;
       verifySigTx.feePayer = senderAddr;
-      verifySigTx.partialSign(signatureSet);
-
-      yield this.createUnsignedTx(verifySigTx, 'Core.VerifySignature', true);
+      yield this.createUnsignedTx(
+        { transaction: verifySigTx, signers: [signatureSet] },
+        'Core.VerifySignature',
+        true,
+      );
     }
 
     // Finally create the VAA posting transaction
@@ -190,10 +188,9 @@ export class SolanaWormholeCore<N extends Network, C extends SolanaChains>
         signatureSet.publicKey,
       ),
     );
-    postVaaTx.recentBlockhash = blockhash;
     postVaaTx.feePayer = senderAddr;
 
-    yield this.createUnsignedTx(postVaaTx, 'Core.PostVAA');
+    yield this.createUnsignedTx({ transaction: postVaaTx }, 'Core.PostVAA');
   }
 
   static parseSequenceFromLog(
@@ -330,7 +327,7 @@ export class SolanaWormholeCore<N extends Network, C extends SolanaChains>
   }
 
   private createUnsignedTx(
-    txReq: Transaction,
+    txReq: SolanaTransaction,
     description: string,
     parallelizable: boolean = false,
   ): SolanaUnsignedTransaction<N, C> {

--- a/platforms/solana/protocols/tokenBridge/src/automaticTokenBridge.ts
+++ b/platforms/solana/protocols/tokenBridge/src/automaticTokenBridge.ts
@@ -16,6 +16,7 @@ import {
   SolanaChains,
   SolanaPlatform,
   SolanaPlatformType,
+  SolanaTransaction,
   SolanaUnsignedTransaction,
 } from '@wormhole-foundation/connect-sdk-solana';
 
@@ -173,18 +174,18 @@ export class SolanaAutomaticTokenBridge<
             nonce,
           );
 
-    const { blockhash } = await SolanaPlatform.latestBlock(this.connection);
-
     transaction.add(transferIx);
-    transaction.recentBlockhash = blockhash;
     transaction.feePayer = senderAddress;
 
-    yield this.createUnsignedTx(transaction, 'AutomaticTokenBridge.Transfer');
+    yield this.createUnsignedTx(
+      { transaction },
+      'AutomaticTokenBridge.Transfer',
+    );
   }
 
   async *redeem(sender: AccountAddress<C>, vaa: AutomaticTokenBridge.VAA) {
-    const redeemTx = new Transaction();
-    yield this.createUnsignedTx(redeemTx, 'AutomaticTokenBridge.Redeem');
+    const transaction = new Transaction();
+    yield this.createUnsignedTx({ transaction }, 'AutomaticTokenBridge.Redeem');
     throw new Error('Method not implemented.');
   }
 
@@ -327,7 +328,7 @@ export class SolanaAutomaticTokenBridge<
   }
 
   private createUnsignedTx(
-    txReq: Transaction,
+    txReq: SolanaTransaction,
     description: string,
     parallelizable: boolean = false,
   ): SolanaUnsignedTransaction<N, C> {

--- a/platforms/solana/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/solana/protocols/tokenBridge/src/tokenBridge.ts
@@ -217,11 +217,12 @@ export class SolanaTokenBridge<N extends Network, C extends SolanaChains>
     const nonce = 0;
 
     const msgFee = await this.coreBridge.getMessageFee();
-    const transferIx = await coreUtils.createBridgeFeeTransferInstruction(
+    const transferIx = coreUtils.createBridgeFeeTransferInstruction(
       this.coreBridge.address,
       senderAddress,
       msgFee,
     );
+
     const messageKey = Keypair.generate();
     const attestIx = createAttestTokenInstruction(
       this.connection,

--- a/platforms/solana/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/solana/protocols/tokenBridge/src/tokenBridge.ts
@@ -218,7 +218,7 @@ export class SolanaTokenBridge<N extends Network, C extends SolanaChains>
 
     const msgFee = await this.coreBridge.getMessageFee();
     const transferIx = coreUtils.createBridgeFeeTransferInstruction(
-      this.coreBridge.address,
+      this.coreBridge.coreBridge.programId,
       senderAddress,
       msgFee,
     );

--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -209,13 +209,11 @@ export class SolanaPlatform<N extends Network> extends PlatformContext<
     rpc: Connection,
     commitment?: Commitment,
   ): Promise<{ blockhash: string; lastValidBlockHeight: number }> {
-    // Use finalized to prevent blockhash not found errors
-    // Note: this may mean we have less time to submit transactions?
-    return rpc.getLatestBlockhash(commitment ?? 'finalized');
+    return rpc.getLatestBlockhash(commitment ?? rpc.commitment);
   }
 
   static async getLatestBlock(rpc: Connection): Promise<number> {
-    const { lastValidBlockHeight } = await this.latestBlock(rpc, 'confirmed');
+    const { lastValidBlockHeight } = await this.latestBlock(rpc);
     return lastValidBlockHeight;
   }
 

--- a/platforms/solana/src/testing/debug.ts
+++ b/platforms/solana/src/testing/debug.ts
@@ -1,0 +1,14 @@
+import { Transaction } from '@solana/web3.js';
+
+export function logTxDetails(transaction: Transaction) {
+  console.log(transaction.signatures);
+  console.log(transaction.feePayer);
+  transaction.instructions.forEach((ix) => {
+    console.log('Program', ix.programId.toBase58());
+    console.log('Data: ', ix.data.toString('hex'));
+    console.log(
+      'Keys: ',
+      ix.keys.map((k) => [k, k.pubkey.toBase58()]),
+    );
+  });
+}

--- a/platforms/solana/src/testing/index.ts
+++ b/platforms/solana/src/testing/index.ts
@@ -13,6 +13,7 @@ export async function getSolanaSigner(
   return new SolanaSigner(
     chain,
     Keypair.fromSecretKey(encoding.b58.decode(privateKey)),
+    rpc,
   );
 }
 

--- a/platforms/solana/src/testing/sendSigner.ts
+++ b/platforms/solana/src/testing/sendSigner.ts
@@ -1,4 +1,10 @@
-import { Connection, Keypair } from '@solana/web3.js';
+import {
+  Connection,
+  Keypair,
+  SendOptions,
+  SendTransactionError,
+  TransactionExpiredBlockheightExceededError,
+} from '@solana/web3.js';
 import {
   SignAndSendSigner,
   UnsignedTransaction,
@@ -7,6 +13,7 @@ import { Network } from '@wormhole-foundation/sdk-base/src';
 import { SolanaPlatform } from '../platform';
 import { SolanaChains } from '../types';
 import { SolanaUnsignedTransaction } from '../unsignedTransaction';
+import { logTxDetails } from './debug';
 
 export class SolanaSendSigner<
   N extends Network,
@@ -18,7 +25,12 @@ export class SolanaSendSigner<
     private _chain: C,
     private _keypair: Keypair,
     private _debug: boolean = false,
-  ) {}
+    private _sendOpts?: SendOptions,
+  ) {
+    this._sendOpts = this._sendOpts ?? {
+      preflightCommitment: this._rpc.commitment,
+    };
+  }
 
   chain(): C {
     return this._chain;
@@ -28,50 +40,96 @@ export class SolanaSendSigner<
     return this._keypair.publicKey.toBase58();
   }
 
+  // Handles retrying a Transaction if the error is deemed to be
+  // recoverable. Currently handles:
+  // - Blockhash not found
+  // - Not enough bytes (storage account not seen yet)
+  private retryable(e: any): boolean {
+    // Tx expired, set a new block hash and retry
+    if (e instanceof TransactionExpiredBlockheightExceededError) return true;
+
+    // Besides tx expiry, only handle SendTransactionError
+    if (!(e instanceof SendTransactionError)) return false;
+
+    // Only handle simulation errors
+    if (!e.message.includes('Transaction simulation failed')) return false;
+
+    // Blockhash not found, similar to expired, resend with new blockhash
+    if (e.message.includes('Blockhash not found')) return true;
+
+    // Find the log message with the error details
+    const loggedErr = e.logs.find((log) =>
+      log.startsWith('Program log: Error: '),
+    );
+
+    // who knows
+    if (!loggedErr) return false;
+
+    // Probably caused by storage account not seen yet
+    if (loggedErr.includes('Not enough bytes')) return true;
+    if (loggedErr.includes('Unexpected length of input')) return true;
+
+    return false;
+  }
+
   async signAndSend(tx: UnsignedTransaction[]): Promise<any[]> {
-    const { blockhash, lastValidBlockHeight } =
-      await SolanaPlatform.latestBlock(this._rpc, 'finalized');
+    let { blockhash, lastValidBlockHeight } = await SolanaPlatform.latestBlock(
+      this._rpc,
+      'finalized',
+    );
 
-    const txPromises: Promise<string>[] = [];
-
+    const txids: string[] = [];
     for (const txn of tx) {
-      const { description, transaction } = txn as SolanaUnsignedTransaction<
-        N,
-        C
-      >;
+      const {
+        description,
+        transaction: { transaction, signers: extraSigners },
+      } = txn as SolanaUnsignedTransaction<N, C>;
       console.log(`Signing: ${description} for ${this.address()}`);
 
-      if (this._debug) {
-        console.log(transaction.signatures);
-        console.log(transaction.feePayer);
-        transaction.instructions.forEach((ix) => {
-          console.log('Program', ix.programId.toBase58());
-          console.log('Data: ', ix.data.toString('hex'));
-          console.log(
-            'Keys: ',
-            ix.keys.map((k) => [k, k.pubkey.toBase58()]),
+      if (this._debug) logTxDetails(transaction);
+
+      // Try to send the transaction up to 5 times
+      for (let i = 0; i < 5; i++) {
+        try {
+          transaction.recentBlockhash = blockhash;
+          transaction.partialSign(this._keypair, ...(extraSigners ?? []));
+
+          const txid = await this._rpc.sendRawTransaction(
+            transaction.serialize(),
+            this._sendOpts,
           );
-        });
+          txids.push(txid);
+          break;
+        } catch (e) {
+          if (!this.retryable(e)) throw e;
+
+          // If it is retryable, we should grab a new block hash
+          ({ blockhash, lastValidBlockHeight } =
+            await SolanaPlatform.latestBlock(this._rpc, 'finalized'));
+        }
       }
-
-      transaction.partialSign(this._keypair);
-
-      txPromises.push(
-        this._rpc.sendRawTransaction(transaction.serialize(), {
-          preflightCommitment: this._rpc.commitment,
-        }),
-      );
     }
-    const txids = await Promise.all(txPromises);
 
     // Wait for finalization
-    for (const signature of txids) {
-      await this._rpc.confirmTransaction({
-        signature,
-        blockhash,
-        lastValidBlockHeight,
-      });
-    }
+    const results = await Promise.all(
+      txids.map((signature) =>
+        this._rpc.confirmTransaction(
+          {
+            signature,
+            blockhash,
+            lastValidBlockHeight,
+          },
+          this._rpc.commitment,
+        ),
+      ),
+    );
+
+    const erroredTxs = results
+      .filter((result) => result.value.err)
+      .map((result) => result.value.err);
+
+    if (erroredTxs.length > 0)
+      throw new Error(`Failed to confirm transaction: ${erroredTxs}`);
 
     return txids;
   }

--- a/platforms/solana/src/testing/signer.ts
+++ b/platforms/solana/src/testing/signer.ts
@@ -27,10 +27,7 @@ export class SolanaSigner<N extends Network, C extends SolanaChains = 'Solana'>
   }
 
   async sign(tx: UnsignedTransaction[]): Promise<any[]> {
-    const { blockhash } = await SolanaPlatform.latestBlock(
-      this._rpc,
-      'finalized',
-    );
+    const { blockhash } = await SolanaPlatform.latestBlock(this._rpc);
 
     const signed = [];
     for (const txn of tx) {

--- a/platforms/solana/src/unsignedTransaction.ts
+++ b/platforms/solana/src/unsignedTransaction.ts
@@ -1,6 +1,11 @@
-import { Transaction } from '@solana/web3.js';
+import { Keypair, Transaction } from '@solana/web3.js';
 import { Network, UnsignedTransaction } from '@wormhole-foundation/connect-sdk';
 import { SolanaChains } from './types';
+
+export type SolanaTransaction = {
+  transaction: Transaction;
+  signers?: Keypair[];
+};
 
 export class SolanaUnsignedTransaction<
   N extends Network,
@@ -8,7 +13,7 @@ export class SolanaUnsignedTransaction<
 > implements UnsignedTransaction
 {
   constructor(
-    readonly transaction: Transaction,
+    readonly transaction: SolanaTransaction,
     readonly network: N,
     readonly chain: C,
     readonly description: string,


### PR DESCRIPTION
Solana transaction changes to make it possible to resubmit a tx

This requires us to pass not only the transaction but all the ephemeral keypairs used to sign the transactions so that the transaction may be updated with a more recent blockhash and re-signed and sent.