### PR TITLE
Use union types for TransferReceipt

### DIFF
--- a/connect/src/protocols/cctpTransfer.ts
+++ b/connect/src/protocols/cctpTransfer.ts
@@ -31,10 +31,6 @@ import { signSendWait } from "../common";
 import { DEFAULT_TASK_TIMEOUT } from "../config";
 import { Wormhole } from "../wormhole";
 import {
-  AttestedTransferReceipt,
-  CompletedTransferReceipt,
-  SourceInitiatedTransferReceipt,
-  SourceFinalizedTransferReceipt,
   TransferQuote,
   TransferReceipt,
   TransferState,
@@ -42,6 +38,7 @@ import {
   isSourceInitiated,
   isSourceFinalized,
   isAttested,
+  AttestedTransferReceipt,
 } from "../wormholeTransfer";
 
 type CircleTransferProtocol = "CircleBridge" | "AutomaticCircleBridge";
@@ -489,9 +486,7 @@ export class CircleTransfer<N extends Network = Network>
 
     const originTxs = xfer.txids.filter((txid) => txid.chain === xfer.transfer.from.chain);
     if (originTxs.length > 0) {
-      receipt = { ...receipt, state: TransferState.SourceInitiated, originTxs } as Partial<
-        SourceInitiatedTransferReceipt<CircleTransferProtocol, Chain, Chain>
-      >;
+      receipt = { ...receipt, state: TransferState.SourceInitiated, originTxs };
     }
 
     const att = xfer.attestations?.filter((a) => isWormholeMessageId(a.id)) ?? [];
@@ -511,7 +506,7 @@ export class CircleTransfer<N extends Network = Network>
         ...receipt,
         state: TransferState.DestinationInitiated,
         destinationTxs,
-      } as CompletedTransferReceipt<CircleTransferProtocol, Chain, Chain>;
+      };
     }
 
     return receipt as TransferReceipt<CircleTransferProtocol>;
@@ -547,7 +542,7 @@ export class CircleTransfer<N extends Network = Network>
         ...receipt,
         attestation: { id: xfermsg },
         state: TransferState.SourceFinalized,
-      } as SourceFinalizedTransferReceipt<CircleTransferProtocol, SC, DC>;
+      };
       yield receipt;
     }
 
@@ -569,7 +564,7 @@ export class CircleTransfer<N extends Network = Network>
             ...receipt,
             attestation: { id: receipt.attestation.id, attestation: vaa },
             state: TransferState.Attested,
-          } as AttestedTransferReceipt<CircleTransferProtocol, SC, DC>;
+          };
           yield receipt;
         }
       }
@@ -592,7 +587,7 @@ export class CircleTransfer<N extends Network = Network>
           ...receipt,
           destinationTxs: [{ chain: toChain(chainId) as DC, txid: txHash }],
           state: TransferState.DestinationFinalized,
-        } as CompletedTransferReceipt<CircleTransferProtocol, SC, DC>;
+        };
         yield receipt;
       }
 
@@ -607,7 +602,7 @@ export class CircleTransfer<N extends Network = Network>
           ))
             ? TransferState.DestinationFinalized
             : TransferState.Attested,
-        } as AttestedTransferReceipt<CircleTransferProtocol, SC, DC>;
+        };
         yield receipt;
       }
     }

--- a/connect/src/protocols/tokenTransfer.ts
+++ b/connect/src/protocols/tokenTransfer.ts
@@ -33,6 +33,7 @@ import { signSendWait } from "../common";
 import { DEFAULT_TASK_TIMEOUT } from "../config";
 import { Wormhole } from "../wormhole";
 import {
+  AttestedTransferReceipt,
   CompletedTransferReceipt,
   TransferQuote,
   TransferReceipt,
@@ -552,7 +553,7 @@ export class TokenTransfer<N extends Network = Network>
         ...receipt,
         state: TransferState.Attested,
         attestation: attestation,
-      };
+      } as AttestedTransferReceipt<TokenTransferProtocol>;
     }
 
     const destinationTxs = xfer.txids.filter((txid) => txid.chain === transfer.to.chain);
@@ -595,8 +596,7 @@ export class TokenTransfer<N extends Network = Network>
         txid,
         leftover(start, timeout),
       );
-      receipt = { ...receipt, state: TransferState.SourceFinalized, attestation: { id: msg } };
-      yield receipt;
+      yield { ...receipt, state: TransferState.SourceFinalized, attestation: { id: msg } };
     }
 
     // If the source is finalized, we need to fetch the signed attestation
@@ -606,8 +606,7 @@ export class TokenTransfer<N extends Network = Network>
       if (!receipt.attestation.id) throw "Attestation id required to fetch attestation";
       const { id } = receipt.attestation;
       const attestation = await TokenTransfer.getTransferVaa(wh, id, leftover(start, timeout));
-      receipt = { ...receipt, attestation: { id, attestation }, state: TransferState.Attested };
-      yield receipt;
+      yield { ...receipt, attestation: { id, attestation }, state: TransferState.Attested };
     }
 
     // First try to grab the tx status from the API

--- a/connect/src/protocols/tokenTransfer.ts
+++ b/connect/src/protocols/tokenTransfer.ts
@@ -533,7 +533,7 @@ export class TokenTransfer<N extends Network = Network>
     const from = transfer.from.chain;
     const to = transfer.to.chain;
 
-    let receipt: Partial<TransferReceipt<TokenTransferProtocol>> = {
+    let receipt: TransferReceipt<TokenTransferProtocol> = {
       protocol,
       request: transfer,
       from: from,
@@ -547,7 +547,7 @@ export class TokenTransfer<N extends Network = Network>
         ...receipt,
         state: TransferState.SourceInitiated,
         originTxs: originTxs,
-      } as SourceInitiatedTransferReceipt<TokenTransferProtocol>;
+      } satisfies SourceInitiatedTransferReceipt<TokenTransferProtocol>;
     }
 
     const att =
@@ -556,31 +556,31 @@ export class TokenTransfer<N extends Network = Network>
     if (attestation) {
       if (attestation.id) {
         receipt = {
-          ...receipt,
+          ...(receipt as SourceInitiatedTransferReceipt<TokenTransferProtocol>),
           state: TransferState.SourceFinalized,
           attestation: { id: attestation.id },
-        } as SourceFinalizedTransferReceipt<TokenTransferProtocol>;
-      }
+        } satisfies SourceFinalizedTransferReceipt<TokenTransferProtocol>;
 
-      if (attestation.attestation) {
-        receipt = {
-          ...receipt,
-          state: TransferState.Attested,
-          attestation: { id: attestation.id, attestation: attestation.attestation },
-        } as AttestedTransferReceipt<TokenTransferProtocol>;
+        if (attestation.attestation) {
+          receipt = {
+            ...receipt,
+            state: TransferState.Attested,
+            attestation: { id: attestation.id, attestation: attestation.attestation },
+          } satisfies AttestedTransferReceipt<TokenTransferProtocol>;
+        }
       }
     }
 
     const destinationTxs = xfer.txids.filter((txid) => txid.chain === transfer.to.chain);
     if (destinationTxs.length > 0) {
       receipt = {
-        ...receipt,
+        ...(receipt as AttestedTransferReceipt<TokenTransferProtocol>),
         state: TransferState.DestinationInitiated,
         destinationTxs: destinationTxs,
-      } as CompletedTransferReceipt<TokenTransferProtocol>;
+      } satisfies CompletedTransferReceipt<TokenTransferProtocol>;
     }
 
-    return receipt as TransferReceipt<TokenTransferProtocol>;
+    return receipt;
   }
 
   // AsyncGenerator fn that produces status updates through an async generator
@@ -615,7 +615,7 @@ export class TokenTransfer<N extends Network = Network>
         ...receipt,
         state: TransferState.SourceFinalized,
         attestation: { id: msg },
-      } as SourceFinalizedTransferReceipt<TokenTransferProtocol, SC, DC>;
+      } satisfies SourceFinalizedTransferReceipt<TokenTransferProtocol>;
       yield receipt;
     }
 
@@ -630,7 +630,7 @@ export class TokenTransfer<N extends Network = Network>
         ...receipt,
         attestation: { id, attestation },
         state: TransferState.Attested,
-      } as AttestedTransferReceipt<TokenTransferProtocol, SC, DC>;
+      } satisfies AttestedTransferReceipt<TokenTransferProtocol>;
       yield receipt;
     }
 
@@ -647,7 +647,7 @@ export class TokenTransfer<N extends Network = Network>
           ...receipt,
           destinationTxs: [{ chain: toChain(chainId) as DC, txid: txHash }],
           state: TransferState.DestinationFinalized,
-        } as CompletedTransferReceipt<TokenTransferProtocol, SC, DC>;
+        } satisfies CompletedTransferReceipt<TokenTransferProtocol>;
       }
       yield receipt;
     }
@@ -666,7 +666,7 @@ export class TokenTransfer<N extends Network = Network>
         receipt = {
           ...receipt,
           state: TransferState.DestinationFinalized,
-        } as CompletedTransferReceipt<TokenTransferProtocol, SC, DC>;
+        } satisfies CompletedTransferReceipt<TokenTransferProtocol>;
       }
 
       yield receipt;

--- a/connect/src/wormholeTransfer.ts
+++ b/connect/src/wormholeTransfer.ts
@@ -90,7 +90,7 @@ export interface CompletedTransferReceipt<
 > extends BaseTransferReceipt<PN, SC, DC> {
   state: TransferState.DestinationInitiated | TransferState.DestinationFinalized;
   originTxs: TransactionId<SC>[];
-  attestation: Required<AttestationReceipt<PN>>;
+  attestation: AttestationReceipt<PN>;
   destinationTxs?: TransactionId<DC>[];
 }
 

--- a/connect/src/wormholeTransfer.ts
+++ b/connect/src/wormholeTransfer.ts
@@ -41,7 +41,7 @@ export enum TransferState {
 }
 
 // Base type for common properties
-export interface BaseTransferReceipt<PN extends ProtocolName, SC extends Chain, DC extends Chain> {
+interface BaseTransferReceipt<PN extends ProtocolName, SC extends Chain, DC extends Chain> {
   protocol: PN;
   from: SC;
   to: DC;
@@ -49,18 +49,26 @@ export interface BaseTransferReceipt<PN extends ProtocolName, SC extends Chain, 
   state: TransferState;
 }
 
+export interface CreatedTransferReceipt<
+  PN extends ProtocolName,
+  SC extends Chain = Chain,
+  DC extends Chain = Chain,
+> extends BaseTransferReceipt<PN, SC, DC> {
+  state: TransferState.Created;
+}
+
 export interface SourceInitiatedTransferReceipt<
   PN extends ProtocolName,
-  SC extends Chain,
-  DC extends Chain,
+  SC extends Chain = Chain,
+  DC extends Chain = Chain,
 > extends BaseTransferReceipt<PN, SC, DC> {
   state: TransferState.SourceInitiated;
   originTxs: TransactionId<SC>[];
 }
 export interface SourceFinalizedTransferReceipt<
   PN extends ProtocolName,
-  SC extends Chain,
-  DC extends Chain,
+  SC extends Chain = Chain,
+  DC extends Chain = Chain,
 > extends BaseTransferReceipt<PN, SC, DC> {
   state: TransferState.SourceFinalized;
   originTxs: TransactionId<SC>[];
@@ -68,8 +76,8 @@ export interface SourceFinalizedTransferReceipt<
 }
 export interface AttestedTransferReceipt<
   PN extends ProtocolName,
-  SC extends Chain,
-  DC extends Chain,
+  SC extends Chain = Chain,
+  DC extends Chain = Chain,
 > extends BaseTransferReceipt<PN, SC, DC> {
   state: TransferState.Attested;
   originTxs: TransactionId<SC>[];
@@ -77,13 +85,13 @@ export interface AttestedTransferReceipt<
 }
 export interface CompletedTransferReceipt<
   PN extends ProtocolName,
-  SC extends Chain,
-  DC extends Chain,
+  SC extends Chain = Chain,
+  DC extends Chain = Chain,
 > extends BaseTransferReceipt<PN, SC, DC> {
   state: TransferState.DestinationInitiated | TransferState.DestinationFinalized;
   originTxs: TransactionId<SC>[];
   attestation: Required<AttestationReceipt<PN>>;
-  destinationTxs: TransactionId<DC>[];
+  destinationTxs?: TransactionId<DC>[];
 }
 
 export function isAttested<PN extends ProtocolName>(
@@ -109,7 +117,7 @@ export type TransferReceipt<
   SC extends Chain = Chain,
   DC extends Chain = Chain,
 > =
-  | BaseTransferReceipt<PN, SC, DC>
+  | CreatedTransferReceipt<PN, SC, DC>
   | SourceInitiatedTransferReceipt<PN, SC, DC>
   | SourceFinalizedTransferReceipt<PN, SC, DC>
   | AttestedTransferReceipt<PN, SC, DC>


### PR DESCRIPTION
This change makes the TransferReceipt code a little more verbose but a lot more legible. And the compile-time checks seems stricter now, because `TransferState` is only kept in one place. So that's nice.