### PR TITLE
fix: holesky chainId

### DIFF
--- a/core/base/src/constants/nativeChainIds.ts
+++ b/core/base/src/constants/nativeChainIds.ts
@@ -243,7 +243,7 @@ const chainNetworkNativeChainIdEntries = [
   ["ArbitrumSepolia", [["Testnet", 421614n]]],
   ["BaseSepolia", [["Testnet", 84532n]]],
   ["OptimismSepolia", [["Testnet", 11155420n]]],
-  ["Holesky", [["Testnet", 11155420n]]],
+  ["Holesky", [["Testnet", 17000n]]],
 ] as const satisfies MapLevel<Chain, MapLevel<Network, bigint | string>>;
 
 export const networkChainToNativeChainId = constMap(chainNetworkNativeChainIdEntries, [[1, 0], 2]);


### PR DESCRIPTION
Holesky is currently defined with Optimism Sepolia's native chain id, blocking either network from being used:

`Error: Platform Evm has multiple chains with native chain id 11155420`

Grabbed chainId from https://github.com/eth-clients/holesky