### PR TITLE
Make numeric type generic on TransferQuote

### DIFF
--- a/connect/src/routes/route.ts
+++ b/connect/src/routes/route.ts
@@ -61,6 +61,7 @@ export type RouteConstructor = {
     fromChain: ChainContext<N>,
     toChain: ChainContext<N>,
   ): Promise<(TokenId | "native")[]>;
+
   isProtocolSupported<N extends Network>(
     fromChain: ChainContext<N>,
     toChain: ChainContext<N>,

--- a/connect/src/routes/types.ts
+++ b/connect/src/routes/types.ts
@@ -15,7 +15,7 @@ export type Receipt<AT extends AttestationReceipt = AttestationReceipt> = Transf
 
 // Quote containing expected details
 // of the transfer
-export interface Quote extends TransferQuote {}
+export type Quote = TransferQuote<bigint | string | number>;
 
 // Transfer params after being validated.
 // Will contain populated options as well

--- a/connect/src/types.ts
+++ b/connect/src/types.ts
@@ -102,28 +102,28 @@ export type TransferReceipt<AT, SC extends Chain = Chain, DC extends Chain = Cha
 
 // Quote with optional relayer fees if the transfer
 // is requested to be automatic
-export interface TransferQuote {
+export interface TransferQuote<NUM = bigint> {
   // How much of what token will be deducted from sender
   // Note: This will include fees charged for a full
   // estimate of the amount taken from the sender
   sourceToken: {
     token: TokenId;
-    amount: bigint;
+    amount: NUM;
   };
   // How much of what token will be minted to the receiver
   // Note: This will _not_ include native gas if requested
   destinationToken: {
     token: TokenId;
-    amount: bigint;
+    amount: NUM;
   };
   // If the transfer being quoted is automatic
   // a relayer fee may apply
   relayFee?: {
     token: TokenId;
-    amount: bigint;
+    amount: NUM;
   };
   // If the transfer being quoted asked for native gas dropoff
   // this will contain the amount of native gas that is to be minted
   // on the destination chain given the current swap rates
-  destinationNativeGas?: bigint;
+  destinationNativeGas?: NUM;
 }


### PR DESCRIPTION
Mayan never uses bigint, let's not force it on people :)