### PR TITLE
Add alias for ChainContext to allow skipping platform generic

### DIFF
--- a/connect/src/common.ts
+++ b/connect/src/common.ts
@@ -1,6 +1,6 @@
-import { Chain, ChainToPlatform, Network } from "@wormhole-foundation/sdk-base";
+import { Chain, Network } from "@wormhole-foundation/sdk-base";
 import {
-  ChainContext,
+  Ctx,
   Signer,
   TransactionId,
   TxHash,
@@ -10,7 +10,7 @@ import {
 } from "@wormhole-foundation/sdk-definitions";
 
 export async function signSendWait<N extends Network, C extends Chain>(
-  chain: ChainContext<N, ChainToPlatform<C>, C>,
+  chain: Ctx<N, C>,
   xfer: AsyncGenerator<UnsignedTransaction<N, C>>,
   signer: Signer<N, C>,
 ): Promise<TransactionId[]> {

--- a/connect/src/protocols/gatewayTransfer.ts
+++ b/connect/src/protocols/gatewayTransfer.ts
@@ -1,5 +1,4 @@
 import {
-  ChainToPlatform,
   Network,
   PlatformToChains,
   chainToPlatform,
@@ -9,7 +8,7 @@ import {
 import {
   AttestationId,
   ChainAddress,
-  ChainContext,
+  Ctx,
   GatewayTransferDetails,
   GatewayTransferMsg,
   GatewayTransferWithPayloadMsg,
@@ -36,11 +35,7 @@ import { TransferState } from "../types";
 import { Wormhole } from "../wormhole";
 import { WormholeTransfer } from "./wormholeTransfer";
 
-type GatewayContext<N extends Network> = ChainContext<
-  N,
-  ChainToPlatform<typeof GatewayTransfer.chain>,
-  typeof GatewayTransfer.chain
->;
+type GatewayContext<N extends Network> = Ctx<N, typeof GatewayTransfer.chain>;
 
 export class GatewayTransfer<N extends Network = Network> implements WormholeTransfer<"IbcBridge"> {
   static chain: "Wormchain" = "Wormchain";

--- a/connect/src/protocols/wormholeTransfer.ts
+++ b/connect/src/protocols/wormholeTransfer.ts
@@ -1,8 +1,8 @@
-import { Network, Platform, PlatformToChains } from "@wormhole-foundation/sdk-base";
+import { Chain, Network } from "@wormhole-foundation/sdk-base";
 import {
   AttestationId,
-  ChainContext,
   CircleTransferDetails,
+  Ctx,
   GatewayTransferDetails,
   ProtocolName,
   Signer,
@@ -25,8 +25,8 @@ export type TransferRequest<PN extends ProtocolName = ProtocolName> = PN extends
 // Static methods on the Transfer protocol types
 // e.g. `TokenTransfer`
 export interface TransferProtocol<PN extends ProtocolName> {
-  isTransferComplete<N extends Network, P extends Platform, C extends PlatformToChains<P>>(
-    toChain: ChainContext<N, P, C>,
+  isTransferComplete<N extends Network, C extends Chain>(
+    toChain: Ctx<N, C>,
     attestation: AttestationId<PN>,
   ): Promise<boolean>;
   validateTransferDetails<N extends Network>(

--- a/connect/src/routes/cctp/automatic.ts
+++ b/connect/src/routes/cctp/automatic.ts
@@ -1,16 +1,22 @@
 import { Chain, Network, circle, contracts } from "@wormhole-foundation/sdk-base";
 import {
-  ChainContext,
   CircleTransferDetails,
+  Ctx,
   Signer,
   TokenId,
   nativeTokenId,
 } from "@wormhole-foundation/sdk-definitions";
 import { CircleAttestationReceipt, CircleTransfer } from "../../protocols/cctpTransfer";
 import { TransferState } from "../../types";
-import { AutomaticRoute, StaticRouteMethods } from "../route";
-import { Quote, Receipt, TransferParams, ValidatedTransferParams, ValidationResult } from "../types";
 import { Wormhole } from "../../wormhole";
+import { AutomaticRoute, StaticRouteMethods } from "../route";
+import {
+  Quote,
+  Receipt,
+  TransferParams,
+  ValidatedTransferParams,
+  ValidationResult,
+} from "../types";
 
 export namespace AutomaticCCTPRoute {
   export type Options = {
@@ -60,7 +66,7 @@ export class AutomaticCCTPRoute<N extends Network>
   }
 
   // get the list of source tokens that are possible to send
-  static async supportedSourceTokens(fromChain: ChainContext<Network>): Promise<TokenId[]> {
+  static async supportedSourceTokens(fromChain: Ctx): Promise<TokenId[]> {
     const { network, chain } = fromChain;
     if (!circle.usdcContract.has(network, chain)) return [];
     return [Wormhole.chainAddress(chain, circle.usdcContract.get(network, chain)!)];
@@ -69,8 +75,8 @@ export class AutomaticCCTPRoute<N extends Network>
   // get the liist of destination tokens that may be recieved on the destination chain
   static async supportedDestinationTokens<N extends Network>(
     sourceToken: TokenId,
-    fromChain: ChainContext<N>,
-    toChain: ChainContext<N>,
+    fromChain: Ctx<N>,
+    toChain: Ctx<N>,
   ): Promise<TokenId[]> {
     const { network, chain } = toChain;
     if (!circle.usdcContract.has(network, chain)) return [];
@@ -80,7 +86,7 @@ export class AutomaticCCTPRoute<N extends Network>
     ];
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
+  static isProtocolSupported(chain: Ctx): boolean {
     return chain.supportsAutomaticCircleBridge();
   }
 
@@ -120,11 +126,13 @@ export class AutomaticCCTPRoute<N extends Network>
   }
 
   async quote(params: Vp) {
-    return this.request.displayQuote(await CircleTransfer.quoteTransfer(
-      this.request.fromChain,
-      this.request.toChain,
-      this.toTransferDetails(params),
-    ));
+    return this.request.displayQuote(
+      await CircleTransfer.quoteTransfer(
+        this.request.fromChain,
+        this.request.toChain,
+        this.toTransferDetails(params),
+      ),
+    );
   }
 
   private async normalizeTransferParams(params: Tp) {

--- a/connect/src/routes/mock/automatic.ts
+++ b/connect/src/routes/mock/automatic.ts
@@ -1,7 +1,7 @@
 import {
   Chain,
-  ChainContext,
   CompletedTransferReceipt,
+  Ctx,
   Network,
   Signer,
   SourceInitiatedTransferReceipt,
@@ -44,20 +44,20 @@ export class AutomaticMockRoute<N extends Network>
   static supportedChains(network: Network): Chain[] {
     return ["Solana", "Ethereum"];
   }
-  static async supportedSourceTokens(fromChain: ChainContext<Network>): Promise<TokenId[]> {
+  static async supportedSourceTokens(fromChain: Ctx): Promise<TokenId[]> {
     await delay(250);
     return [nativeTokenId(fromChain.chain)];
   }
   static async supportedDestinationTokens<N extends Network>(
     sourceToken: TokenId,
-    fromChain: ChainContext<N>,
-    toChain: ChainContext<N>,
+    fromChain: Ctx<N>,
+    toChain: Ctx<N>,
   ): Promise<TokenId[]> {
     await delay(250);
     return [nativeTokenId(toChain.chain)];
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
+  static isProtocolSupported(chain: Ctx): boolean {
     return true;
   }
 

--- a/connect/src/routes/mock/manual.ts
+++ b/connect/src/routes/mock/manual.ts
@@ -1,7 +1,7 @@
 import {
   Chain,
-  ChainContext,
   CompletedTransferReceipt,
+  Ctx,
   Network,
   Signer,
   SourceInitiatedTransferReceipt,
@@ -43,20 +43,21 @@ export class ManualMockRoute<N extends Network>
   static supportedChains(network: Network): Chain[] {
     return ["Solana", "Ethereum"];
   }
-  static async supportedSourceTokens(fromChain: ChainContext<Network>): Promise<TokenId[]> {
+
+  static async supportedSourceTokens(fromChain: Ctx): Promise<TokenId[]> {
     await delay(250);
     return [nativeTokenId(fromChain.chain)];
   }
   static async supportedDestinationTokens<N extends Network>(
     sourceToken: TokenId,
-    fromChain: ChainContext<N>,
-    toChain: ChainContext<N>,
+    fromChain: Ctx<N>,
+    toChain: Ctx<N>,
   ): Promise<TokenId[]> {
     await delay(250);
     return [nativeTokenId(toChain.chain)];
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
+  static isProtocolSupported(chain: Ctx): boolean {
     return true;
   }
 

--- a/connect/src/routes/request.ts
+++ b/connect/src/routes/request.ts
@@ -1,10 +1,5 @@
 import { Network, displayAmount, normalizeAmount } from "@wormhole-foundation/sdk-base";
-import {
-  ChainAddress,
-  ChainContext,
-  TokenId,
-  isSameToken,
-} from "@wormhole-foundation/sdk-definitions";
+import { ChainAddress, Ctx, TokenId, isSameToken } from "@wormhole-foundation/sdk-definitions";
 import { TransferQuote } from "../types";
 import { Wormhole } from "../wormhole";
 import { TokenDetails, getTokenDetails } from "./token";
@@ -16,14 +11,14 @@ export class RouteTransferRequest<N extends Network> {
   source: TokenDetails;
   destination?: TokenDetails;
 
-  fromChain: ChainContext<N>;
-  toChain: ChainContext<N>;
+  fromChain: Ctx<N>;
+  toChain: Ctx<N>;
 
   private constructor(
     from: ChainAddress,
     to: ChainAddress,
-    fromChain: ChainContext<N>,
-    toChain: ChainContext<N>,
+    fromChain: Ctx<N>,
+    toChain: Ctx<N>,
     source: TokenDetails,
     destination?: TokenDetails,
   ) {
@@ -101,8 +96,8 @@ export class RouteTransferRequest<N extends Network> {
       source: TokenId;
       destination?: TokenId;
     },
-    fromChain?: ChainContext<N>,
-    toChain?: ChainContext<N>,
+    fromChain?: Ctx<N>,
+    toChain?: Ctx<N>,
   ) {
     fromChain = fromChain ?? wh.getChain(params.from.chain);
     toChain = toChain ?? wh.getChain(params.to.chain);

--- a/connect/src/routes/resolver.ts
+++ b/connect/src/routes/resolver.ts
@@ -1,5 +1,5 @@
 import { Network } from "@wormhole-foundation/sdk-base";
-import { ChainContext, TokenId, resolveWrappedToken } from "@wormhole-foundation/sdk-definitions";
+import { Ctx, TokenId, resolveWrappedToken } from "@wormhole-foundation/sdk-definitions";
 import { Wormhole } from "../wormhole";
 import { RouteTransferRequest } from "./request";
 import { Route, RouteConstructor, isAutomatic } from "./route";
@@ -17,7 +17,7 @@ export class RouteResolver<N extends Network> {
     this.routeConstructors = routeConstructors;
   }
 
-  async supportedSourceTokens(chain: ChainContext<Network>): Promise<TokenId[]> {
+  async supportedSourceTokens(chain: Ctx<N>): Promise<TokenId[]> {
     if (this.inputTokenList) return this.inputTokenList;
     const itl = await Promise.all(
       this.routeConstructors.map(async (rc) => rc.supportedSourceTokens(chain)),
@@ -28,8 +28,8 @@ export class RouteResolver<N extends Network> {
 
   async supportedDestinationTokens(
     inputToken: TokenId,
-    fromChain: ChainContext<Network>,
-    toChain: ChainContext<Network>,
+    fromChain: Ctx<N>,
+    toChain: Ctx<N>,
   ): Promise<TokenId[]> {
     const [, inputTokenId] = resolveWrappedToken(fromChain.network, fromChain.chain, inputToken);
     const tokens = await Promise.all(

--- a/connect/src/routes/route.ts
+++ b/connect/src/routes/route.ts
@@ -1,5 +1,5 @@
 import { Chain, Network } from "@wormhole-foundation/sdk-base";
-import { ChainContext, Signer, TokenId, TransactionId } from "@wormhole-foundation/sdk-definitions";
+import { Ctx, Signer, TokenId, TransactionId } from "@wormhole-foundation/sdk-definitions";
 import { Wormhole } from "../wormhole";
 import { RouteTransferRequest } from "./request";
 import {
@@ -68,14 +68,14 @@ export interface RouteConstructor {
   // get the list of chains this route supports
   supportedChains(network: Network): Chain[];
   // make sure the underlying protocols are supported
-  isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean;
+  isProtocolSupported(chain: Ctx): boolean;
   // get the list of source tokens that are possible to send
-  supportedSourceTokens(fromChain: ChainContext<Network>): Promise<TokenId[]>;
+  supportedSourceTokens(fromChain: Ctx): Promise<TokenId[]>;
   // get the list of destination tokens that may be recieved on the destination chain
   supportedDestinationTokens<N extends Network>(
     token: TokenId,
-    fromChain: ChainContext<N>,
-    toChain: ChainContext<N>,
+    fromChain: Ctx<N>,
+    toChain: Ctx<N>,
   ): Promise<TokenId[]>;
 }
 

--- a/connect/src/routes/token.ts
+++ b/connect/src/routes/token.ts
@@ -1,10 +1,5 @@
 import { Chain, Network, tokens } from "@wormhole-foundation/sdk-base";
-import {
-  ChainContext,
-  TokenId,
-  canonicalAddress,
-  isNative,
-} from "@wormhole-foundation/sdk-definitions";
+import { Ctx, TokenId, canonicalAddress, isNative } from "@wormhole-foundation/sdk-definitions";
 import { Wormhole } from "../wormhole";
 
 export interface TokenDetails {
@@ -31,7 +26,7 @@ export function tokenAddresses(tokens: TokenId[]): string[] {
 }
 
 export async function getTokenDetails<N extends Network>(
-  chain: ChainContext<N>,
+  chain: Ctx<N>,
   token: TokenId,
 ): Promise<TokenDetails> {
   const address = canonicalAddress(token);

--- a/connect/src/routes/tokenBridge/automatic.ts
+++ b/connect/src/routes/tokenBridge/automatic.ts
@@ -1,6 +1,6 @@
 import { Chain, Network, contracts } from "@wormhole-foundation/sdk-base";
 import {
-  ChainContext,
+  Ctx,
   Signer,
   TokenId,
   TokenTransferDetails,
@@ -12,7 +12,13 @@ import {
 import { TokenTransfer } from "../../protocols/tokenTransfer";
 import { AttestationReceipt, TransferState } from "../../types";
 import { AutomaticRoute, StaticRouteMethods } from "../route";
-import { Quote, Receipt, TransferParams, ValidatedTransferParams, ValidationResult } from "../types";
+import {
+  Quote,
+  Receipt,
+  TransferParams,
+  ValidatedTransferParams,
+  ValidationResult,
+} from "../types";
 
 export namespace AutomaticTokenBridgeRoute {
   export type Options = {
@@ -62,7 +68,7 @@ export class AutomaticTokenBridgeRoute<N extends Network>
   }
 
   // get the list of source tokens that are possible to send
-  static async supportedSourceTokens(fromChain: ChainContext<Network>): Promise<TokenId[]> {
+  static async supportedSourceTokens(fromChain: Ctx): Promise<TokenId[]> {
     const atb = await fromChain.getAutomaticTokenBridge();
     const registered = await atb.getRegisteredTokens();
     return [
@@ -76,8 +82,8 @@ export class AutomaticTokenBridgeRoute<N extends Network>
   // get the liist of destination tokens that may be recieved on the destination chain
   static async supportedDestinationTokens<N extends Network>(
     sourceToken: TokenId,
-    fromChain: ChainContext<N>,
-    toChain: ChainContext<N>,
+    fromChain: Ctx<N>,
+    toChain: Ctx<N>,
   ): Promise<TokenId[]> {
     return [
       nativeTokenId(toChain.chain),
@@ -85,7 +91,7 @@ export class AutomaticTokenBridgeRoute<N extends Network>
     ];
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
+  static isProtocolSupported(chain: Ctx): boolean {
     return chain.supportsAutomaticTokenBridge();
   }
 
@@ -204,11 +210,13 @@ export class AutomaticTokenBridgeRoute<N extends Network>
   }
 
   async quote(params: Vp) {
-    return this.request.displayQuote(await TokenTransfer.quoteTransfer(
-      this.request.fromChain,
-      this.request.toChain,
-      this.toTransferDetails(params),
-    ));
+    return this.request.displayQuote(
+      await TokenTransfer.quoteTransfer(
+        this.request.fromChain,
+        this.request.toChain,
+        this.toTransferDetails(params),
+      ),
+    );
   }
 
   async initiate(signer: Signer, params: Vp): Promise<R> {

--- a/connect/src/routes/tokenBridge/manual.ts
+++ b/connect/src/routes/tokenBridge/manual.ts
@@ -1,18 +1,13 @@
 import { Chain, Network, contracts } from "@wormhole-foundation/sdk-base";
 import {
-  ChainContext,
+  Ctx,
   Signer,
   TokenId,
   TokenTransferDetails,
   TransactionId,
 } from "@wormhole-foundation/sdk-definitions";
 import { TokenTransfer, TokenTransferVAA } from "../../protocols/tokenTransfer";
-import {
-  AttestationReceipt,
-  TransferReceipt,
-  TransferState,
-  isAttested,
-} from "../../types";
+import { AttestationReceipt, TransferReceipt, TransferState, isAttested } from "../../types";
 import { Wormhole } from "../../wormhole";
 import { ManualRoute, StaticRouteMethods } from "../route";
 import { Quote, TransferParams, ValidatedTransferParams, ValidationResult } from "../types";
@@ -57,7 +52,7 @@ export class TokenBridgeRoute<N extends Network>
   }
 
   // get the list of source tokens that are possible to send
-  static async supportedSourceTokens(fromChain: ChainContext<Network>): Promise<TokenId[]> {
+  static async supportedSourceTokens(fromChain: Ctx): Promise<TokenId[]> {
     // Default list for the chain
     return Object.values(fromChain.config.tokenMap!).map((td) =>
       Wormhole.tokenId(td.chain, td.address),
@@ -67,13 +62,13 @@ export class TokenBridgeRoute<N extends Network>
   // get the liist of destination tokens that may be recieved on the destination chain
   static async supportedDestinationTokens<N extends Network>(
     sourceToken: TokenId,
-    fromChain: ChainContext<N>,
-    toChain: ChainContext<N>,
+    fromChain: Ctx<N>,
+    toChain: Ctx<N>,
   ): Promise<TokenId[]> {
     return [await TokenTransfer.lookupDestinationToken(fromChain, toChain, sourceToken)];
   }
 
-  static isProtocolSupported<N extends Network>(chain: ChainContext<N>): boolean {
+  static isProtocolSupported(chain: Ctx): boolean {
     return chain.supportsTokenBridge();
   }
 
@@ -97,11 +92,13 @@ export class TokenBridgeRoute<N extends Network>
   }
 
   async quote(params: Vp) {
-    return this.request.displayQuote(await TokenTransfer.quoteTransfer(
-      this.request.fromChain,
-      this.request.toChain,
-      this.toTransferDetails(params),
-    ));
+    return this.request.displayQuote(
+      await TokenTransfer.quoteTransfer(
+        this.request.fromChain,
+        this.request.toChain,
+        this.toTransferDetails(params),
+      ),
+    );
   }
 
   async initiate(signer: Signer, params: Vp): Promise<R> {

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -1,16 +1,8 @@
-import {
-  Chain,
-  ChainToPlatform,
-  Network,
-  Platform,
-  PlatformToChains,
-  chainToPlatform,
-  circle,
-} from "@wormhole-foundation/sdk-base";
+import { Chain, Network, Platform, chainToPlatform, circle } from "@wormhole-foundation/sdk-base";
 import {
   ChainAddress,
-  ChainContext,
   Contracts,
+  Ctx,
   NativeAddress,
   PayloadDiscriminator,
   PayloadLiteral,
@@ -43,10 +35,7 @@ import {
 } from "./whscan-api";
 
 type PlatformMap<N extends Network, P extends Platform = Platform> = Map<P, PlatformContext<N, P>>;
-type ChainMap<N extends Network, C extends Chain = Chain> = Map<
-  C,
-  ChainContext<N, ChainToPlatform<C>, C>
->;
+type ChainMap<N extends Network, C extends Chain = Chain> = Map<C, Ctx<N, C>>;
 
 export class Wormhole<N extends Network> {
   protected readonly _network: N;
@@ -194,11 +183,11 @@ export class Wormhole<N extends Network> {
    * @returns the chain context class
    * @throws Errors if context is not found
    */
-  getChain<C extends Chain, P extends ChainToPlatform<C>>(chain: C): ChainContext<N, P, C> {
+  getChain<C extends Chain>(chain: C): Ctx<N, C> {
     const platform = chainToPlatform(chain);
     if (!this._chains.has(chain))
       this._chains.set(chain, this.getPlatform(platform).getChain(chain));
-    return this._chains.get(chain)! as ChainContext<N, P, C>;
+    return this._chains.get(chain)! as Ctx<N, C>;
   }
 
   /**
@@ -412,12 +401,8 @@ export class Wormhole<N extends Network> {
    * @param tx The sending transaction hash
    * @returns The parsed WormholeMessageId
    */
-  static async parseMessageFromTx<
-    N extends Network,
-    P extends Platform,
-    C extends PlatformToChains<P>,
-  >(
-    chain: ChainContext<N, P, C>,
+  static async parseMessageFromTx<N extends Network, C extends Chain>(
+    chain: Ctx<N, C>,
     txid: TxHash,
     timeout: number = DEFAULT_TASK_TIMEOUT,
   ): Promise<WormholeMessageId[]> {

--- a/core/definitions/src/chain.ts
+++ b/core/definitions/src/chain.ts
@@ -1,4 +1,11 @@
-import { Chain, Network, Platform, PlatformToChains, tokens } from "@wormhole-foundation/sdk-base";
+import {
+  ChainToPlatform,
+  Chain,
+  Network,
+  Platform,
+  PlatformToChains,
+  tokens,
+} from "@wormhole-foundation/sdk-base";
 import { ChainAddress, UniversalOrNative, toNative } from "./address";
 import { WormholeMessageId } from "./attestation";
 import { PlatformContext } from "./platform";
@@ -10,6 +17,13 @@ import { AutomaticTokenBridge, TokenBridge } from "./protocols/tokenBridge";
 import { RpcConnection } from "./rpc";
 import { ChainConfig, SignedTx, TokenId, TokenAddress } from "./types";
 import { PorticoBridge } from "./protocols/portico";
+
+// Utility type to ease generic parameter setting
+export type Ctx<N extends Network = Network, C extends Chain = Chain> = ChainContext<
+  N,
+  ChainToPlatform<C>,
+  C
+>;
 
 export abstract class ChainContext<
   N extends Network,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9795,6 +9795,7 @@
       }
     },
     "platforms/evm/protocols/portico": {
+      "name": "@wormhole-foundation/connect-sdk-evm-portico",
       "version": "0.4.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
This is 1 new type + using it wherever we had `ChainContext`
new type:
https://github.com/wormhole-foundation/connect-sdk/blob/simplify-chainctx-generics/core/definitions/src/chain.ts#L21-L27