### PR TITLE
Remove Platform generic parameter from ChainContext and Protocol definitions

### DIFF
--- a/connect/src/common.ts
+++ b/connect/src/common.ts
@@ -1,4 +1,4 @@
-import { Chain, ChainToPlatform, Network } from "@wormhole-foundation/sdk-base";
+import { Chain, Network } from "@wormhole-foundation/sdk-base";
 import {
   ChainContext,
   Signer,
@@ -10,7 +10,7 @@ import {
 } from "@wormhole-foundation/sdk-definitions";
 
 export async function signSendWait<N extends Network, C extends Chain>(
-  chain: ChainContext<N, ChainToPlatform<C>, C>,
+  chain: ChainContext<N, C>,
   xfer: AsyncGenerator<UnsignedTransaction<N, C>>,
   signer: Signer<N, C>,
 ): Promise<TransactionId[]> {

--- a/connect/src/protocols/cctpTransfer.ts
+++ b/connect/src/protocols/cctpTransfer.ts
@@ -1,12 +1,4 @@
-import {
-  Chain,
-  ChainToPlatform,
-  Network,
-  Platform,
-  circle,
-  encoding,
-  toChain,
-} from "@wormhole-foundation/sdk-base";
+import { Chain, Network, circle, encoding, toChain } from "@wormhole-foundation/sdk-base";
 import {
   Attestation,
   AttestationId,
@@ -58,8 +50,8 @@ export class CircleTransfer<N extends Network = Network>
 {
   private readonly wh: Wormhole<N>;
 
-  fromChain: ChainContext<N, Platform, Chain>;
-  toChain: ChainContext<N, Platform, Chain>;
+  fromChain: ChainContext<N, Chain>;
+  toChain: ChainContext<N, Chain>;
 
   // state machine tracker
   private _state: TransferState;
@@ -75,8 +67,8 @@ export class CircleTransfer<N extends Network = Network>
   private constructor(
     wh: Wormhole<N>,
     transfer: CircleTransferDetails,
-    fromChain?: ChainContext<N, Platform, Chain>,
-    toChain?: ChainContext<N, Platform, Chain>,
+    fromChain?: ChainContext<N, Chain>,
+    toChain?: ChainContext<N, Chain>,
   ) {
     this._state = TransferState.Created;
     this.wh = wh;
@@ -95,36 +87,36 @@ export class CircleTransfer<N extends Network = Network>
     wh: Wormhole<N>,
     from: CircleTransferDetails,
     timeout?: number,
-    fromChain?: ChainContext<N, Platform, Chain>,
-    toChain?: ChainContext<N, Platform, Chain>,
+    fromChain?: ChainContext<N, Chain>,
+    toChain?: ChainContext<N, Chain>,
   ): Promise<CircleTransfer<N>>;
   static async from<N extends Network>(
     wh: Wormhole<N>,
     from: WormholeMessageId,
     timeout?: number,
-    fromChain?: ChainContext<N, Platform, Chain>,
-    toChain?: ChainContext<N, Platform, Chain>,
+    fromChain?: ChainContext<N, Chain>,
+    toChain?: ChainContext<N, Chain>,
   ): Promise<CircleTransfer<N>>;
   static async from<N extends Network>(
     wh: Wormhole<N>,
     from: string, // CircleMessage hex encoded
     timeout?: number,
-    fromChain?: ChainContext<N, Platform, Chain>,
-    toChain?: ChainContext<N, Platform, Chain>,
+    fromChain?: ChainContext<N, Chain>,
+    toChain?: ChainContext<N, Chain>,
   ): Promise<CircleTransfer<N>>;
   static async from<N extends Network>(
     wh: Wormhole<N>,
     from: TransactionId,
     timeout?: number,
-    fromChain?: ChainContext<N, Platform, Chain>,
-    toChain?: ChainContext<N, Platform, Chain>,
+    fromChain?: ChainContext<N, Chain>,
+    toChain?: ChainContext<N, Chain>,
   ): Promise<CircleTransfer<N>>;
   static async from<N extends Network>(
     wh: Wormhole<N>,
     from: CircleTransferDetails | WormholeMessageId | string | TransactionId,
     timeout: number = DEFAULT_TASK_TIMEOUT,
-    fromChain?: ChainContext<N, Platform, Chain>,
-    toChain?: ChainContext<N, Platform, Chain>,
+    fromChain?: ChainContext<N, Chain>,
+    toChain?: ChainContext<N, Chain>,
   ): Promise<CircleTransfer<N>> {
     // This is a new transfer, just return the object
     if (isCircleTransferDetails(from)) {
@@ -220,7 +212,7 @@ export class CircleTransfer<N extends Network = Network>
     wh: Wormhole<N>,
     from: TransactionId,
     timeout: number,
-    fromChain?: ChainContext<N, Platform, Chain>,
+    fromChain?: ChainContext<N, Chain>,
   ): Promise<CircleTransfer<N>> {
     const { chain, txid } = from;
     fromChain = fromChain ?? wh.getChain(chain);
@@ -274,7 +266,7 @@ export class CircleTransfer<N extends Network = Network>
   }
 
   static async transfer<N extends Network, C extends Chain = Chain>(
-    fromChain: ChainContext<N, Platform, C>,
+    fromChain: ChainContext<N, C>,
     transfer: CircleTransferDetails,
     signer: Signer<N, Chain>,
   ): Promise<TransactionId[]> {
@@ -425,8 +417,8 @@ export class CircleTransfer<N extends Network = Network>
   }
 
   static async quoteTransfer<N extends Network>(
-    srcChain: ChainContext<N, Platform, Chain>,
-    dstChain: ChainContext<N, Platform, Chain>,
+    srcChain: ChainContext<N, Chain>,
+    dstChain: ChainContext<N, Chain>,
     transfer: CircleTransferDetails,
   ): Promise<TransferQuote> {
     const dstUsdcAddress = circle.usdcContract.get(dstChain.network, dstChain.chain);
@@ -477,7 +469,7 @@ export class CircleTransfer<N extends Network = Network>
   }
 
   static async isTransferComplete<N extends Network>(
-    toChain: ChainContext<N, Platform, Chain>,
+    toChain: ChainContext<N, Chain>,
     attestation: Attestation<CircleTransferProtocol>,
   ) {
     if (!CircleBridge.isCircleAttestation(attestation))
@@ -501,7 +493,7 @@ export class CircleTransfer<N extends Network = Network>
   }
 
   static async getTransferMessage<N extends Network>(
-    fromChain: ChainContext<N, Platform, Chain>,
+    fromChain: ChainContext<N, Chain>,
     txid: TxHash,
   ) {
     const cb = await fromChain.getCircleBridge();
@@ -572,8 +564,8 @@ export class CircleTransfer<N extends Network = Network>
     receipt: CircleTransferReceipt<SC, DC>,
     timeout: number = DEFAULT_TASK_TIMEOUT,
     // Optional parameters to override chain context (typically for custom rpc)
-    _fromChain?: ChainContext<N, ChainToPlatform<SC>, SC>,
-    _toChain?: ChainContext<N, ChainToPlatform<DC>, DC>,
+    _fromChain?: ChainContext<N, SC>,
+    _toChain?: ChainContext<N, DC>,
   ): AsyncGenerator<CircleTransferReceipt<SC, DC>> {
     const start = Date.now();
     const leftover = (start: number, max: number) => Math.max(max - (Date.now() - start), 0);

--- a/connect/src/protocols/gatewayTransfer.ts
+++ b/connect/src/protocols/gatewayTransfer.ts
@@ -45,7 +45,7 @@ export class GatewayTransfer<N extends Network = Network> implements WormholeTra
   // Wormchain context
   private readonly gateway: GatewayContext<N>;
   // Wormchain IBC Bridge
-  private readonly gatewayIbcBridge: IbcBridge<N, "Cosmwasm", PlatformToChains<"Cosmwasm">>;
+  private readonly gatewayIbcBridge: IbcBridge<N, PlatformToChains<"Cosmwasm">>;
   // Contract address
   private readonly gatewayAddress: ChainAddress;
 
@@ -77,7 +77,7 @@ export class GatewayTransfer<N extends Network = Network> implements WormholeTra
     wh: Wormhole<N>,
     transfer: GatewayTransferDetails,
     gateway: GatewayContext<N>,
-    gatewayIbc: IbcBridge<N, "Cosmwasm", PlatformToChains<"Cosmwasm">>,
+    gatewayIbc: IbcBridge<N, PlatformToChains<"Cosmwasm">>,
   ) {
     this._state = TransferState.Created;
     this.wh = wh;

--- a/connect/src/protocols/gatewayTransfer.ts
+++ b/connect/src/protocols/gatewayTransfer.ts
@@ -1,5 +1,4 @@
 import {
-  ChainToPlatform,
   Network,
   PlatformToChains,
   chainToPlatform,
@@ -36,11 +35,7 @@ import { TransferState } from "../types";
 import { Wormhole } from "../wormhole";
 import { WormholeTransfer } from "./wormholeTransfer";
 
-type GatewayContext<N extends Network> = ChainContext<
-  N,
-  ChainToPlatform<typeof GatewayTransfer.chain>,
-  typeof GatewayTransfer.chain
->;
+type GatewayContext<N extends Network> = ChainContext<N, typeof GatewayTransfer.chain>;
 
 export class GatewayTransfer<N extends Network = Network> implements WormholeTransfer<"IbcBridge"> {
   static chain: "Wormchain" = "Wormchain";

--- a/connect/src/protocols/wormholeTransfer.ts
+++ b/connect/src/protocols/wormholeTransfer.ts
@@ -1,4 +1,4 @@
-import { Network, Platform, PlatformToChains } from "@wormhole-foundation/sdk-base";
+import { Chain, Network } from "@wormhole-foundation/sdk-base";
 import {
   AttestationId,
   ChainContext,
@@ -25,8 +25,8 @@ export type TransferRequest<PN extends ProtocolName = ProtocolName> = PN extends
 // Static methods on the Transfer protocol types
 // e.g. `TokenTransfer`
 export interface TransferProtocol<PN extends ProtocolName> {
-  isTransferComplete<N extends Network, P extends Platform, C extends PlatformToChains<P>>(
-    toChain: ChainContext<N, P, C>,
+  isTransferComplete<N extends Network, C extends Chain>(
+    toChain: ChainContext<N, C>,
     attestation: AttestationId<PN>,
   ): Promise<boolean>;
   validateTransferDetails<N extends Network>(

--- a/connect/src/tasks.ts
+++ b/connect/src/tasks.ts
@@ -1,4 +1,4 @@
-import { PlatformToChains, Chain, Network, Platform } from "@wormhole-foundation/sdk-base";
+import { Chain, Network, Platform, PlatformToChains } from "@wormhole-foundation/sdk-base";
 import {
   GatewayTransferMsg,
   GatewayTransferWithPayloadMsg,
@@ -63,7 +63,7 @@ export async function isTokenBridgeVaaRedeemed<
   N extends Network,
   P extends Platform,
   C extends Chain,
->(tb: TokenBridge<N, P, C>, vaa: TokenBridge.TransferVAA): Promise<boolean | null> {
+>(tb: TokenBridge<N, C>, vaa: TokenBridge.TransferVAA): Promise<boolean | null> {
   try {
     const isRedeemed = await tb.isTransferCompleted(vaa);
     // Only return a real value if its true, otherwise return null
@@ -76,7 +76,7 @@ export async function isTokenBridgeVaaRedeemed<
 }
 
 export async function fetchIbcXfer<N extends Network, C extends PlatformToChains<"Cosmwasm">>(
-  wcIbc: IbcBridge<N, "Cosmwasm", C>,
+  wcIbc: IbcBridge<N, C>,
   msg: TxHash | TransactionId | IbcMessageId | GatewayTransferMsg | GatewayTransferWithPayloadMsg,
 ): Promise<IbcTransferInfo | null> {
   try {

--- a/connect/src/wormhole.ts
+++ b/connect/src/wormhole.ts
@@ -1,12 +1,4 @@
-import {
-  Chain,
-  ChainToPlatform,
-  Network,
-  Platform,
-  PlatformToChains,
-  chainToPlatform,
-  circle,
-} from "@wormhole-foundation/sdk-base";
+import { Chain, Network, Platform, chainToPlatform, circle } from "@wormhole-foundation/sdk-base";
 import {
   ChainAddress,
   ChainContext,
@@ -43,10 +35,7 @@ import {
 } from "./whscan-api";
 
 type PlatformMap<N extends Network, P extends Platform = Platform> = Map<P, PlatformContext<N, P>>;
-type ChainMap<N extends Network, C extends Chain = Chain> = Map<
-  C,
-  ChainContext<N, ChainToPlatform<C>, C>
->;
+type ChainMap<N extends Network, C extends Chain = Chain> = Map<C, ChainContext<N, C>>;
 
 export class Wormhole<N extends Network> {
   protected readonly _network: N;
@@ -186,11 +175,11 @@ export class Wormhole<N extends Network> {
    * @returns the chain context class
    * @throws Errors if context is not found
    */
-  getChain<C extends Chain, P extends ChainToPlatform<C>>(chain: C): ChainContext<N, P, C> {
+  getChain<C extends Chain>(chain: C): ChainContext<N, C> {
     const platform = chainToPlatform(chain);
     if (!this._chains.has(chain))
       this._chains.set(chain, this.getPlatform(platform).getChain(chain));
-    return this._chains.get(chain)! as ChainContext<N, P, C>;
+    return this._chains.get(chain)! as ChainContext<N, C>;
   }
 
   /**
@@ -404,12 +393,8 @@ export class Wormhole<N extends Network> {
    * @param tx The sending transaction hash
    * @returns The parsed WormholeMessageId
    */
-  static async parseMessageFromTx<
-    N extends Network,
-    P extends Platform,
-    C extends PlatformToChains<P>,
-  >(
-    chain: ChainContext<N, P, C>,
+  static async parseMessageFromTx<N extends Network, C extends Chain>(
+    chain: ChainContext<N, C>,
     txid: TxHash,
     timeout: number = DEFAULT_TASK_TIMEOUT,
   ): Promise<WormholeMessageId[]> {

--- a/core/base/src/constants/platforms.ts
+++ b/core/base/src/constants/platforms.ts
@@ -71,9 +71,7 @@ export const isPlatform = (platform: string): platform is Platform =>
   platformToChains.has(platform);
 
 export type PlatformToChains<P extends Platform> = ReturnType<typeof platformToChains<P>>[number];
-export type ChainToPlatform<C extends Chain> = NonNullable<
-  ReturnType<(typeof chainToPlatform<C>)["get"]>
->;
+export type ChainToPlatform<C extends Chain> = ReturnType<typeof chainToPlatform<C>>;
 
 // prettier-ignore
 const platformAddressFormatEntries = [

--- a/core/base/src/constants/platforms.ts
+++ b/core/base/src/constants/platforms.ts
@@ -71,7 +71,9 @@ export const isPlatform = (platform: string): platform is Platform =>
   platformToChains.has(platform);
 
 export type PlatformToChains<P extends Platform> = ReturnType<typeof platformToChains<P>>[number];
-export type ChainToPlatform<C extends Chain> = ReturnType<typeof chainToPlatform<C>>;
+export type ChainToPlatform<C extends Chain> = NonNullable<
+  ReturnType<(typeof chainToPlatform<C>)["get"]>
+>;
 
 // prettier-ignore
 const platformAddressFormatEntries = [

--- a/core/base/src/utils/mapping.ts
+++ b/core/base/src/utils/mapping.ts
@@ -293,36 +293,11 @@ export type ToMapping<
 
 type Mapped = { [key: PropertyKey]: unknown | Mapped };
 
-// type RecursiveAccess<M extends Mapped, KA extends RoArray<MappableKey>> =
-//   KA extends readonly [infer Head extends MappableKey, ...infer Tail extends RoArray<MappableKey>]
-//   ? M[ToExtPropKey<Head>] extends infer V
-//     ? Tail["length"] extends 0
-//       ? V
-//       : V extends Mapped
-//       ? RecursiveAccess<V, Tail>
-//       : never
-//     : never
-//   : M;
-
-//TODO why does this new, ostensibly better implementation not work when the old, shitty one does?
-//  I suspect it has something to do with with the distribution introduced by infer V but I'm not
-//  sure
-// type RecursiveAccess<M extends Mapped, KA extends RoArray<MappableKey>> =
-//   KA extends readonly [infer Head extends MappableKey, ...infer Tail extends RoArray<MappableKey>]
-//   ? M[ToExtPropKey<Head>] extends infer V extends keyof M
-//     ? V extends Mapped
-//       ? RecursiveAccess<V, Tail>
-//       : V
-//     : never
-//   : M;
-
-type RecursiveAccess<M extends Mapped, KA extends RoArray<MappableKey>> =
+type RecursiveAccess<M, KA extends RoArray<MappableKey>> =
   KA extends readonly [infer Head extends MappableKey, ...infer Tail extends RoArray<MappableKey>]
-  ? ToExtPropKey<Head> extends keyof M
-  ? M[ToExtPropKey<Head>] extends Mapped
-  ? RecursiveAccess<M[ToExtPropKey<Head>], Tail>
-  : M[ToExtPropKey<Head>]
-  : never
+  ? M extends Mapped
+    ? RecursiveAccess<M[ToExtPropKey<Head>], Tail>
+    : never
   : M;
 
 //4 layers deep ought to be enough for anyone ;) (couldn't figure out a way to make this recursive

--- a/core/definitions/src/chain.ts
+++ b/core/definitions/src/chain.ts
@@ -29,13 +29,13 @@ export abstract class ChainContext<
 
   // Cached Protocol clients
   protected rpc?: RpcConnection<P>;
-  protected coreBridge?: WormholeCore<N, P, C>;
-  protected tokenBridge?: TokenBridge<N, P, C>;
-  protected autoTokenBridge?: AutomaticTokenBridge<N, P, C>;
-  protected circleBridge?: CircleBridge<N, P, C>;
-  protected autoCircleBridge?: AutomaticCircleBridge<N, P, C>;
-  protected ibcBridge?: IbcBridge<N, P, C>;
-  protected porticoBridge?: PorticoBridge<N, P, C>;
+  protected coreBridge?: WormholeCore<N, C>;
+  protected tokenBridge?: TokenBridge<N, C>;
+  protected autoTokenBridge?: AutomaticTokenBridge<N, C>;
+  protected circleBridge?: CircleBridge<N, C>;
+  protected autoCircleBridge?: AutomaticCircleBridge<N, C>;
+  protected ibcBridge?: IbcBridge<N, C>;
+  protected porticoBridge?: PorticoBridge<N, C>;
 
   constructor(chain: C, platform: PlatformContext<N, P>, rpc?: RpcConnection<P>) {
     this.config = platform.config[chain]!;
@@ -191,7 +191,7 @@ export abstract class ChainContext<
    * Get the Wormhole Core protocol client for this chain
    * @returns the Wormhole Core protocol client for this chain
    */
-  async getWormholeCore(): Promise<WormholeCore<N, P, C>> {
+  async getWormholeCore(): Promise<WormholeCore<N, C>> {
     this.coreBridge = this.coreBridge
       ? this.coreBridge
       : await this.platform.getProtocol("WormholeCore", await this.getRpc());
@@ -207,7 +207,7 @@ export abstract class ChainContext<
    * Get the Token Bridge protocol client for this chain
    * @returns the Token Bridge protocol client for this chain
    */
-  async getTokenBridge(): Promise<TokenBridge<N, P, C>> {
+  async getTokenBridge(): Promise<TokenBridge<N, C>> {
     this.tokenBridge = this.tokenBridge
       ? this.tokenBridge
       : await this.platform.getProtocol("TokenBridge", await this.getRpc());
@@ -223,7 +223,7 @@ export abstract class ChainContext<
    * Get the Automatic Token Bridge protocol client for this chain
    * @returns the Automatic Token Bridge protocol client for this chain
    */
-  async getAutomaticTokenBridge(): Promise<AutomaticTokenBridge<N, P, C>> {
+  async getAutomaticTokenBridge(): Promise<AutomaticTokenBridge<N, C>> {
     this.autoTokenBridge = this.autoTokenBridge
       ? this.autoTokenBridge
       : await this.platform.getProtocol("AutomaticTokenBridge", await this.getRpc());
@@ -239,7 +239,7 @@ export abstract class ChainContext<
    * Get the Circle Bridge protocol client for this chain
    * @returns the Circle Bridge protocol client for this chain
    */
-  async getCircleBridge(): Promise<CircleBridge<N, P, C>> {
+  async getCircleBridge(): Promise<CircleBridge<N, C>> {
     this.circleBridge = this.circleBridge
       ? this.circleBridge
       : await this.platform.getProtocol("CircleBridge", await this.getRpc());
@@ -255,7 +255,7 @@ export abstract class ChainContext<
    * Get the Automatic Circle Bridge protocol client for this chain
    * @returns the Automatic Circle Bridge protocol client for this chain
    */
-  async getAutomaticCircleBridge(): Promise<AutomaticCircleBridge<N, P, C>> {
+  async getAutomaticCircleBridge(): Promise<AutomaticCircleBridge<N, C>> {
     this.autoCircleBridge = this.autoCircleBridge
       ? this.autoCircleBridge
       : await this.platform.getProtocol("AutomaticCircleBridge", await this.getRpc());
@@ -271,7 +271,7 @@ export abstract class ChainContext<
    * Get the IBC Bridge protocol client for this chain
    * @returns the IBC Bridge protocol client for this chain
    */
-  async getIbcBridge(): Promise<IbcBridge<N, P, C>> {
+  async getIbcBridge(): Promise<IbcBridge<N, C>> {
     this.ibcBridge = this.ibcBridge
       ? this.ibcBridge
       : await this.platform.getProtocol("IbcBridge", await this.getRpc());
@@ -287,7 +287,7 @@ export abstract class ChainContext<
    * Get the Portico Bridge protocol client for this chain
    * @returns the Portico Bridge protocol client for this chain
    */
-  async getPorticoBridge(): Promise<PorticoBridge<N, P, C>> {
+  async getPorticoBridge(): Promise<PorticoBridge<N, C>> {
     this.porticoBridge = this.porticoBridge
       ? this.porticoBridge
       : await this.platform.getProtocol("PorticoBridge", await this.getRpc());

--- a/core/definitions/src/chain.ts
+++ b/core/definitions/src/chain.ts
@@ -1,4 +1,5 @@
-import { Chain, Network, Platform, PlatformToChains, tokens } from "@wormhole-foundation/sdk-base";
+import { Chain, Network, Platform, tokens } from "@wormhole-foundation/sdk-base";
+import { ChainToPlatform } from "@wormhole-foundation/sdk-base/src";
 import { ChainAddress, UniversalOrNative, toNative } from "./address";
 import { WormholeMessageId } from "./attestation";
 import { PlatformContext } from "./platform";
@@ -6,10 +7,10 @@ import { ProtocolName, protocolIsRegistered } from "./protocol";
 import { AutomaticCircleBridge, CircleBridge } from "./protocols/circleBridge";
 import { WormholeCore } from "./protocols/core";
 import { IbcBridge } from "./protocols/ibc";
+import { PorticoBridge } from "./protocols/portico";
 import { AutomaticTokenBridge, TokenBridge } from "./protocols/tokenBridge";
 import { RpcConnection } from "./rpc";
-import { ChainConfig, SignedTx, TokenId, TokenAddress } from "./types";
-import { PorticoBridge } from "./protocols/portico";
+import { ChainConfig, SignedTx, TokenAddress, TokenId } from "./types";
 
 /**
  * A ChainContext provides a consistent interface for interacting with a chain.
@@ -18,8 +19,8 @@ import { PorticoBridge } from "./protocols/portico";
  */
 export abstract class ChainContext<
   N extends Network,
-  P extends Platform = Platform,
-  C extends Chain = PlatformToChains<P>,
+  C extends Chain = Chain,
+  P extends Platform = ChainToPlatform<C>,
 > {
   readonly network: N;
 

--- a/core/definitions/src/chain.ts
+++ b/core/definitions/src/chain.ts
@@ -23,11 +23,9 @@ export abstract class ChainContext<
   P extends Platform = ChainToPlatform<C>,
 > {
   readonly network: N;
-
-  readonly platform: PlatformContext<N, P>;
-
   readonly chain: C;
   readonly config: ChainConfig<N, C>;
+  readonly platform: PlatformContext<N, P>;
 
   // Cached Protocol clients
   protected rpc?: RpcConnection<P>;

--- a/core/definitions/src/platform.ts
+++ b/core/definitions/src/platform.ts
@@ -121,7 +121,7 @@ export abstract class PlatformContext<N extends Network, P extends Platform> {
     rpc: RpcConnection<P>,
     txid: TxHash,
   ): Promise<WormholeMessageId[]> {
-    const wc: WormholeCore<N, P, C> = await this.getProtocol("WormholeCore", rpc);
+    const wc: WormholeCore<N, C> = await this.getProtocol("WormholeCore", rpc);
     return wc.parseTransaction(txid);
   }
 }

--- a/core/definitions/src/platform.ts
+++ b/core/definitions/src/platform.ts
@@ -108,7 +108,7 @@ export abstract class PlatformContext<N extends Network, P extends Platform> {
   abstract getChain<C extends PlatformToChains<P>>(
     chain: C,
     rpc?: RpcConnection<P>,
-  ): ChainContext<N, P, C>;
+  ): ChainContext<N, C>;
 
   /** Create a new Protocol Client instance by protocol name */
   getProtocol<PN extends ProtocolName, T>(protocol: PN, rpc: RpcConnection<P>): Promise<T> {

--- a/core/definitions/src/protocols/circleBridge.ts
+++ b/core/definitions/src/protocols/circleBridge.ts
@@ -3,7 +3,6 @@ import {
   LayoutToType,
   Network,
   Platform,
-  PlatformToChains,
   deserializeLayout,
   encoding,
   lazyInstantiate,
@@ -16,9 +15,9 @@ import { UnsignedTransaction } from "../unsignedTransaction";
 
 import "../payloads/automaticCircleBridge";
 import { circleMessageLayout } from "../payloads/circleBridge";
+import { EmptyPlatformMap } from "../protocol";
 import { keccak256 } from "../utils";
 import { ProtocolPayload, ProtocolVAA, payloadDiscriminator } from "../vaa";
-import { EmptyPlatformMap } from "../protocol";
 
 declare global {
   namespace WormholeNamespace {
@@ -116,11 +115,7 @@ export function isCircleTransferDetails(thing: any): thing is CircleTransferDeta
  * Find the source contracts here: ${@link https://github.com/circlefin/evm-cctp-contracts}
  *
  */
-export interface CircleBridge<
-  N extends Network,
-  P extends Platform,
-  C extends PlatformToChains<P>,
-> {
+export interface CircleBridge<N extends Network, C extends Chain> {
   /**
    * Redeem a circle transfer against the Circle Bridge
    *
@@ -167,11 +162,7 @@ export interface CircleBridge<
  * AutomaticCircleBridge protocol definition, providing a consistent client
  * interface for the CircleBridge protocol with Automatic delivery.
  */
-export interface AutomaticCircleBridge<
-  N extends Network,
-  P extends Platform,
-  C extends Chain = PlatformToChains<P>,
-> {
+export interface AutomaticCircleBridge<N extends Network, C extends Chain> {
   /**
    * Get the fee required by the relayer to cover the costs of redemption on the destination chain
    *

--- a/core/definitions/src/protocols/core.ts
+++ b/core/definitions/src/protocols/core.ts
@@ -1,10 +1,10 @@
-import { PlatformToChains, Network, Platform } from "@wormhole-foundation/sdk-base";
+import { Chain, Network, Platform } from "@wormhole-foundation/sdk-base";
 import { AccountAddress } from "../address";
 import { WormholeMessageId } from "../attestation";
+import { EmptyPlatformMap } from "../protocol";
 import { TxHash } from "../types";
 import { UnsignedTransaction } from "../unsignedTransaction";
 import { VAA } from "../vaa";
-import { EmptyPlatformMap } from "../protocol";
 
 declare global {
   namespace WormholeNamespace {
@@ -19,11 +19,7 @@ declare global {
  * with the Wormhole core messaging protocol.
  *
  */
-export interface WormholeCore<
-  N extends Network,
-  P extends Platform,
-  C extends PlatformToChains<P>,
-> {
+export interface WormholeCore<N extends Network, C extends Chain> {
   /** Get the fee for publishing a message */
   getMessageFee(): Promise<bigint>;
   /**

--- a/core/definitions/src/protocols/ibc.ts
+++ b/core/definitions/src/protocols/ibc.ts
@@ -3,16 +3,15 @@ import {
   ChainId,
   Network,
   Platform,
-  PlatformToChains,
   encoding,
   toChain,
   toChainId,
 } from "@wormhole-foundation/sdk-base";
 import { AccountAddress, ChainAddress, NativeAddress } from "../address";
 import { IbcMessageId, WormholeMessageId } from "../attestation";
-import { TokenId, TxHash, TokenAddress } from "../types";
-import { UnsignedTransaction } from "../unsignedTransaction";
 import { EmptyPlatformMap } from "../protocol";
+import { TokenAddress, TokenId, TxHash } from "../types";
+import { UnsignedTransaction } from "../unsignedTransaction";
 
 declare global {
   namespace WormholeNamespace {
@@ -199,7 +198,7 @@ export interface IbcTransferData {
  * See more here {@link https://tutorials.cosmos.network/academy/3-ibc/7-token-transfer.html}
  *
  */
-export interface IbcBridge<N extends Network, P extends Platform, C extends PlatformToChains<P>> {
+export interface IbcBridge<N extends Network, C extends Chain> {
   /** Initiate an IBC token transfer */
   transfer(
     sender: AccountAddress<C>,

--- a/core/definitions/src/protocols/portico.ts
+++ b/core/definitions/src/protocols/portico.ts
@@ -1,8 +1,8 @@
 import {
+  Chain,
   LayoutToType,
   Network,
   Platform,
-  PlatformToChains,
   deserializeLayout,
   serializeLayout,
 } from "@wormhole-foundation/sdk-base";
@@ -10,7 +10,7 @@ import { AccountAddress, ChainAddress } from "../address";
 import "../payloads/portico";
 import { porticoFlagSetLayout, porticoPayloadLayout } from "../payloads/portico";
 import { EmptyPlatformMap } from "../protocol";
-import { TokenId, TokenAddress } from "../types";
+import { TokenAddress, TokenId } from "../types";
 import { UnsignedTransaction } from "../unsignedTransaction";
 import { ProtocolVAA } from "../vaa";
 
@@ -74,11 +74,7 @@ export namespace PorticoBridge {
  * PorticoBridge provides a consistent interface to interact with
  * the Portico bridge contracts.
  */
-export interface PorticoBridge<
-  N extends Network,
-  P extends Platform,
-  C extends PlatformToChains<P>,
-> {
+export interface PorticoBridge<N extends Network, C extends Chain> {
   // Checks if a transfer VAA has been redeemed
   //isTransferCompleted(vaa: PorticoBridge.VAA): Promise<boolean>;
 

--- a/core/definitions/src/protocols/tokenBridge.ts
+++ b/core/definitions/src/protocols/tokenBridge.ts
@@ -1,17 +1,11 @@
-import {
-  Chain,
-  Network,
-  Platform,
-  PlatformToChains,
-  lazyInstantiate,
-} from "@wormhole-foundation/sdk-base";
+import { Chain, Network, Platform, lazyInstantiate } from "@wormhole-foundation/sdk-base";
 import { AccountAddress, ChainAddress, NativeAddress, UniversalOrNative } from "../address";
 import "../payloads/automaticTokenBridge";
 import "../payloads/tokenBridge";
+import { EmptyPlatformMap } from "../protocol";
 import { TokenAddress, TokenId } from "../types";
 import { UnsignedTransaction } from "../unsignedTransaction";
 import { ProtocolPayload, ProtocolVAA, payloadDiscriminator } from "../vaa";
-import { EmptyPlatformMap } from "../protocol";
 
 export const ErrNotWrapped = (token: string) => new Error(`Token ${token} is not a wrapped asset`);
 
@@ -118,7 +112,7 @@ export function isTokenTransferDetails(
  * Find details on the TokenBridge protocol here: {@link https://github.com/wormhole-foundation/wormhole/blob/main/whitepapers/0003_token_bridge.md}
  *
  */
-export interface TokenBridge<N extends Network, P extends Platform, C extends PlatformToChains<P>> {
+export interface TokenBridge<N extends Network, C extends Chain> {
   /** Checks a native address to see if its a wrapped version
    *
    * @param nativeAddress The address to check
@@ -223,11 +217,7 @@ export interface TokenBridge<N extends Network, P extends Platform, C extends Pl
  *  AutomaticTokenBridge provides a consistent interface to the
  *  TokenBridge with Automatic redemption on the destination chain
  */
-export interface AutomaticTokenBridge<
-  N extends Network,
-  P extends Platform,
-  C extends PlatformToChains<P>,
-> {
+export interface AutomaticTokenBridge<N extends Network, C extends Chain> {
   /** Initiate the transfer over the automatic bridge */
   transfer(
     sender: AccountAddress<C>,

--- a/core/definitions/src/testing/mocks/chain.ts
+++ b/core/definitions/src/testing/mocks/chain.ts
@@ -1,19 +1,16 @@
 import { Chain, Network, Platform, PlatformToChains } from "@wormhole-foundation/sdk-base";
+import { ChainToPlatform } from "@wormhole-foundation/sdk-base/src";
 import { ChainContext, PlatformContext } from "../..";
 
 export function chainFactory<N extends Network, P extends Platform, C extends PlatformToChains<P>>(
   p: PlatformContext<N, P>,
   chain: C,
-): ChainContext<N, P, C> {
+): ChainContext<N, C> {
   return p.getChain(chain);
 }
 
-export class MockChain<
-  N extends Network,
-  P extends Platform,
-  C extends Chain = PlatformToChains<P>,
-> extends ChainContext<N, P, C> {
-  constructor(chain: C, platform: PlatformContext<N, P>) {
+export class MockChain<N extends Network, C extends Chain = Chain> extends ChainContext<N, C> {
+  constructor(chain: C, platform: PlatformContext<N, ChainToPlatform<C>>) {
     super(chain, platform);
   }
 }

--- a/core/definitions/src/testing/mocks/platform.ts
+++ b/core/definitions/src/testing/mocks/platform.ts
@@ -1,13 +1,13 @@
-import { Chain, Network, Platform, PlatformToChains } from "@wormhole-foundation/sdk-base";
+import { Network, Platform, PlatformToChains } from "@wormhole-foundation/sdk-base";
 import {
   ChainContext,
   ChainsConfig,
   PlatformContext,
   PlatformUtils,
+  ProtocolName,
   RpcConnection,
   TokenAddress,
   TokenId,
-  ProtocolName,
 } from "../..";
 import { MockChain } from "./chain";
 import { MockRpc } from "./rpc";
@@ -91,8 +91,9 @@ export class MockPlatform<N extends Network, P extends Platform> extends Platfor
   //   throw new Error("Method not implemented.");
   // }
 
-  getChain<C extends Chain>(chain: C): ChainContext<N, P, C> {
-    if (chain in this.config) return new MockChain<N, P, C>(chain, this);
+  getChain<C extends PlatformToChains<P>>(chain: C): ChainContext<N, C> {
+    // @ts-ignore
+    if (chain in this.config) return new MockChain<N, C>(chain, this);
     throw new Error("No configuration available for chain: " + chain);
   }
 

--- a/core/definitions/src/testing/mocks/tokenBridge.ts
+++ b/core/definitions/src/testing/mocks/tokenBridge.ts
@@ -1,15 +1,15 @@
-import { PlatformToChains, Network, Platform } from "@wormhole-foundation/sdk-base";
+import { Network, Platform, PlatformToChains } from "@wormhole-foundation/sdk-base";
 import {
-  TokenAddress,
   ChainAddress,
   NativeAddress,
   RpcConnection,
+  TokenAddress,
   TokenBridge,
   UnsignedTransaction,
 } from "../..";
 
 export class MockTokenBridge<N extends Network, P extends Platform, C extends PlatformToChains<P>>
-  implements TokenBridge<N, P, C>
+  implements TokenBridge<N, C>
 {
   constructor(readonly rpc: RpcConnection<P>) {}
 

--- a/platforms/algorand/protocols/core/src/core.ts
+++ b/platforms/algorand/protocols/core/src/core.ts
@@ -1,6 +1,4 @@
 import {
-  keccak256,
-  serialize,
   ChainId,
   ChainsConfig,
   Contracts,
@@ -9,6 +7,8 @@ import {
   WormholeCore,
   WormholeMessageId,
   encoding,
+  keccak256,
+  serialize,
   toChainId,
 } from "@wormhole-foundation/connect-sdk";
 import {
@@ -38,7 +38,7 @@ import {
 import { SEED_AMT, StorageLogicSig } from "./storage";
 
 export class AlgorandWormholeCore<N extends Network, C extends AlgorandChains>
-  implements WormholeCore<N, "Algorand", C>
+  implements WormholeCore<N, C>
 {
   readonly chainId: ChainId;
   readonly coreAppId: bigint;

--- a/platforms/algorand/protocols/core/src/core.ts
+++ b/platforms/algorand/protocols/core/src/core.ts
@@ -15,7 +15,6 @@ import {
   AlgorandAddress,
   AlgorandChains,
   AlgorandPlatform,
-  AlgorandPlatformType,
   AlgorandUnsignedTransaction,
   AnyAlgorandAddress,
   TransactionSet,
@@ -39,7 +38,7 @@ import {
 import { SEED_AMT, StorageLogicSig } from "./storage";
 
 export class AlgorandWormholeCore<N extends Network, C extends AlgorandChains>
-  implements WormholeCore<N, AlgorandPlatformType, C>
+  implements WormholeCore<N, "Algorand", C>
 {
   readonly chainId: ChainId;
   readonly coreAppId: bigint;
@@ -107,7 +106,7 @@ export class AlgorandWormholeCore<N extends Network, C extends AlgorandChains>
 
   static async fromRpc<N extends Network>(
     connection: Algodv2,
-    config: ChainsConfig<N, AlgorandPlatformType>,
+    config: ChainsConfig<N, "Algorand">,
   ): Promise<AlgorandWormholeCore<N, AlgorandChains>> {
     const [network, chain] = await AlgorandPlatform.chainFromRpc(connection);
     const conf = config[chain]!;

--- a/platforms/algorand/protocols/core/src/index.ts
+++ b/platforms/algorand/protocols/core/src/index.ts
@@ -1,8 +1,7 @@
-import { _platform } from "@wormhole-foundation/connect-sdk-algorand";
 import { registerProtocol } from "@wormhole-foundation/connect-sdk";
 import { AlgorandWormholeCore } from "./core";
 
-registerProtocol(_platform, "WormholeCore", AlgorandWormholeCore);
+registerProtocol("Algorand", "WormholeCore", AlgorandWormholeCore);
 
 export * from "./core";
 export * from "./storage";

--- a/platforms/algorand/protocols/tokenBridge/src/index.ts
+++ b/platforms/algorand/protocols/tokenBridge/src/index.ts
@@ -1,7 +1,6 @@
-import { _platform } from "@wormhole-foundation/connect-sdk-algorand";
 import { registerProtocol } from "@wormhole-foundation/connect-sdk";
 import { AlgorandTokenBridge } from "./tokenBridge";
 
-registerProtocol(_platform, "TokenBridge", AlgorandTokenBridge);
+registerProtocol("Algorand", "TokenBridge", AlgorandTokenBridge);
 
 export * from "./tokenBridge";

--- a/platforms/algorand/protocols/tokenBridge/src/index.ts
+++ b/platforms/algorand/protocols/tokenBridge/src/index.ts
@@ -1,6 +1,7 @@
 import { registerProtocol } from "@wormhole-foundation/connect-sdk";
+import { _platform } from "@wormhole-foundation/connect-sdk-algorand";
 import { AlgorandTokenBridge } from "./tokenBridge";
 
-registerProtocol("Algorand", "TokenBridge", AlgorandTokenBridge);
+registerProtocol(_platform, "TokenBridge", AlgorandTokenBridge);
 
 export * from "./tokenBridge";

--- a/platforms/algorand/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/algorand/protocols/tokenBridge/src/tokenBridge.ts
@@ -23,7 +23,6 @@ import {
   AlgorandAddress,
   AlgorandChains,
   AlgorandPlatform,
-  AlgorandPlatformType,
   AlgorandUnsignedTransaction,
   AnyAlgorandAddress,
   TransactionSignerPair,
@@ -54,7 +53,7 @@ import "@wormhole-foundation/connect-sdk-algorand-core";
 export const TransferMethodSelector = ABIMethod.fromSignature("portal_transfer(byte[])byte[]");
 
 export class AlgorandTokenBridge<N extends Network, C extends AlgorandChains>
-  implements TokenBridge<N, AlgorandPlatformType, C>
+  implements TokenBridge<N, "Algorand", C>
 {
   readonly chainId: ChainId;
 

--- a/platforms/algorand/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/algorand/protocols/tokenBridge/src/tokenBridge.ts
@@ -13,11 +13,11 @@ import {
   TokenId,
   UniversalAddress,
   encoding,
+  isNative,
   serialize,
   toChain,
   toChainId,
   toNative,
-  isNative,
 } from "@wormhole-foundation/connect-sdk";
 import {
   AlgorandAddress,
@@ -53,7 +53,7 @@ import "@wormhole-foundation/connect-sdk-algorand-core";
 export const TransferMethodSelector = ABIMethod.fromSignature("portal_transfer(byte[])byte[]");
 
 export class AlgorandTokenBridge<N extends Network, C extends AlgorandChains>
-  implements TokenBridge<N, "Algorand", C>
+  implements TokenBridge<N, C>
 {
   readonly chainId: ChainId;
 

--- a/platforms/algorand/src/address.ts
+++ b/platforms/algorand/src/address.ts
@@ -7,7 +7,7 @@ import {
 } from "@wormhole-foundation/connect-sdk";
 
 import { AlgorandPlatform } from "./platform";
-import { _platform, AnyAlgorandAddress, safeBigIntToNumber } from "./types";
+import { AnyAlgorandAddress, safeBigIntToNumber } from "./types";
 import { decodeAddress, encodeAddress, isValidAddress } from "algosdk";
 
 export const AlgorandZeroAddress = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ";
@@ -17,7 +17,7 @@ export const AlgorandZeroAddress = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 
 export class AlgorandAddress implements Address {
   static readonly byteSize = 32;
-  static readonly platform: Platform = _platform;
+  static readonly platform: Platform = "Algorand";
 
   readonly type: string = "Native";
 
@@ -92,4 +92,4 @@ declare global {
   }
 }
 
-registerNative(_platform, AlgorandAddress);
+registerNative("Algorand", AlgorandAddress);

--- a/platforms/algorand/src/address.ts
+++ b/platforms/algorand/src/address.ts
@@ -6,9 +6,9 @@ import {
   registerNative,
 } from "@wormhole-foundation/connect-sdk";
 
-import { AlgorandPlatform } from "./platform";
-import { AnyAlgorandAddress, safeBigIntToNumber } from "./types";
 import { decodeAddress, encodeAddress, isValidAddress } from "algosdk";
+import { AlgorandPlatform } from "./platform";
+import { AnyAlgorandAddress, _platform, safeBigIntToNumber } from "./types";
 
 export const AlgorandZeroAddress = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAY5HFKQ";
 
@@ -17,7 +17,7 @@ export const AlgorandZeroAddress = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 
 export class AlgorandAddress implements Address {
   static readonly byteSize = 32;
-  static readonly platform: Platform = "Algorand";
+  static readonly platform: Platform = _platform;
 
   readonly type: string = "Native";
 
@@ -92,4 +92,4 @@ declare global {
   }
 }
 
-registerNative("Algorand", AlgorandAddress);
+registerNative(_platform, AlgorandAddress);

--- a/platforms/algorand/src/chain.ts
+++ b/platforms/algorand/src/chain.ts
@@ -1,7 +1,7 @@
-import { Chain, ChainContext, Network } from "@wormhole-foundation/connect-sdk";
+import { ChainContext, Network } from "@wormhole-foundation/connect-sdk";
 import { AlgorandChains } from "./types";
 
 export class AlgorandChain<
   N extends Network = Network,
-  C extends Chain = AlgorandChains,
+  C extends AlgorandChains = AlgorandChains,
 > extends ChainContext<N, C> {}

--- a/platforms/algorand/src/chain.ts
+++ b/platforms/algorand/src/chain.ts
@@ -1,7 +1,7 @@
 import { Chain, ChainContext, Network } from "@wormhole-foundation/connect-sdk";
-import { AlgorandChains, AlgorandPlatformType } from "./types";
+import { AlgorandChains } from "./types";
 
 export class AlgorandChain<
   N extends Network = Network,
   C extends Chain = AlgorandChains,
-> extends ChainContext<N, AlgorandPlatformType, C> {}
+> extends ChainContext<N, C> {}

--- a/platforms/algorand/src/platform.ts
+++ b/platforms/algorand/src/platform.ts
@@ -45,6 +45,7 @@ export class AlgorandPlatform<N extends Network>
   }
 
   getChain<C extends AlgorandChains>(chain: C): AlgorandChain<N, C> {
+    // @ts-ignore
     if (chain in this.config) return new AlgorandChain<N, C>(chain, this);
     throw new Error("No configuration available for chain: " + chain);
   }

--- a/platforms/algorand/src/platform.ts
+++ b/platforms/algorand/src/platform.ts
@@ -24,18 +24,18 @@ import {
 } from "algosdk";
 import { AlgorandAddress, AlgorandZeroAddress } from "./address";
 import { AlgorandChain } from "./chain";
-import { AlgorandChains, AnyAlgorandAddress } from "./types";
+import { AlgorandChains, AlgorandPlatformType, AnyAlgorandAddress, _platform } from "./types";
 
 /**
  * @category Algorand
  */
 export class AlgorandPlatform<N extends Network>
-  extends PlatformContext<N, "Algorand">
-  implements StaticPlatformMethods<"Algorand", typeof AlgorandPlatform>
+  extends PlatformContext<N, AlgorandPlatformType>
+  implements StaticPlatformMethods<AlgorandPlatformType, typeof AlgorandPlatform>
 {
-  static _platform: "Algorand" = "Algorand";
+  static _platform = _platform;
 
-  constructor(network: N, _config?: ChainsConfig<N, "Algorand">) {
+  constructor(network: N, _config?: ChainsConfig<N, AlgorandPlatformType>) {
     super(network, _config ?? networkPlatformConfigs(network, AlgorandPlatform._platform));
   }
 

--- a/platforms/algorand/src/platform.ts
+++ b/platforms/algorand/src/platform.ts
@@ -46,7 +46,7 @@ export class AlgorandPlatform<N extends Network>
 
   getChain<C extends AlgorandChains>(chain: C): AlgorandChain<N, C> {
     // @ts-ignore
-    if (chain in this.config) return new AlgorandChain<N, C>(chain, this);
+    if (chain in this.config) return new AlgorandChain(chain, this);
     throw new Error("No configuration available for chain: " + chain);
   }
 

--- a/platforms/algorand/src/platform.ts
+++ b/platforms/algorand/src/platform.ts
@@ -24,18 +24,18 @@ import {
 } from "algosdk";
 import { AlgorandAddress, AlgorandZeroAddress } from "./address";
 import { AlgorandChain } from "./chain";
-import { AlgorandChains, AlgorandPlatformType, AnyAlgorandAddress, _platform } from "./types";
+import { AlgorandChains, AnyAlgorandAddress } from "./types";
 
 /**
  * @category Algorand
  */
 export class AlgorandPlatform<N extends Network>
-  extends PlatformContext<N, AlgorandPlatformType>
-  implements StaticPlatformMethods<typeof _platform, typeof AlgorandPlatform>
+  extends PlatformContext<N, "Algorand">
+  implements StaticPlatformMethods<"Algorand", typeof AlgorandPlatform>
 {
-  static _platform = _platform;
+  static _platform: "Algorand" = "Algorand";
 
-  constructor(network: N, _config?: ChainsConfig<N, AlgorandPlatformType>) {
+  constructor(network: N, _config?: ChainsConfig<N, "Algorand">) {
     super(network, _config ?? networkPlatformConfigs(network, AlgorandPlatform._platform));
   }
 
@@ -55,7 +55,7 @@ export class AlgorandPlatform<N extends Network>
     chain: C,
   ): TokenId<C> {
     if (!AlgorandPlatform.isSupportedChain(chain))
-      throw new Error(`invalid chain for ${_platform}: ${chain}`);
+      throw new Error(`invalid chain for Algorand: ${chain}`);
     return Wormhole.chainAddress(chain, AlgorandZeroAddress);
   }
 

--- a/platforms/algorand/src/platform.ts
+++ b/platforms/algorand/src/platform.ts
@@ -45,7 +45,6 @@ export class AlgorandPlatform<N extends Network>
   }
 
   getChain<C extends AlgorandChains>(chain: C): AlgorandChain<N, C> {
-    // @ts-ignore
     if (chain in this.config) return new AlgorandChain(chain, this);
     throw new Error("No configuration available for chain: " + chain);
   }

--- a/platforms/algorand/src/signer.ts
+++ b/platforms/algorand/src/signer.ts
@@ -18,7 +18,7 @@ export async function getAlgorandSigner(
 }
 
 // AlgorandSigner implements SignOnlySender
-export class AlgorandSigner<N extends Network, C extends AlgorandChains = "Algorand">
+export class AlgorandSigner<N extends Network, C extends AlgorandChains>
   implements SignOnlySigner<N, C>
 {
   _account: Account;

--- a/platforms/algorand/src/types.ts
+++ b/platforms/algorand/src/types.ts
@@ -1,16 +1,16 @@
 import { PlatformToChains, UniversalOrNative } from "@wormhole-foundation/connect-sdk";
 import { Transaction } from "algosdk";
 
-/**
- * Runtime value for the Algorand Platform
- */
-export const _platform: "Algorand" = "Algorand";
-/**
- * Compile time Type for the Algorand Platform
- */
-export type AlgorandPlatformType = typeof _platform;
+// /**
+//  * Runtime value for the Algorand Platform
+//  */
+// export const _platform: "Algorand" = "Algorand";
+// /**
+//  * Compile time Type for the Algorand Platform
+//  */
+// export type AlgorandPlatformType = typeof _platform;
 
-export type AlgorandChains = PlatformToChains<AlgorandPlatformType>;
+export type AlgorandChains = PlatformToChains<"Algorand">;
 export type UniversalOrAlgorand = UniversalOrNative<AlgorandChains>;
 export type AnyAlgorandAddress = UniversalOrAlgorand | string | Uint8Array | bigint;
 

--- a/platforms/algorand/src/types.ts
+++ b/platforms/algorand/src/types.ts
@@ -1,16 +1,16 @@
 import { PlatformToChains, UniversalOrNative } from "@wormhole-foundation/connect-sdk";
 import { Transaction } from "algosdk";
 
-// /**
-//  * Runtime value for the Algorand Platform
-//  */
-// export const _platform: "Algorand" = "Algorand";
-// /**
-//  * Compile time Type for the Algorand Platform
-//  */
-// export type AlgorandPlatformType = typeof _platform;
+/**
+ * Runtime value for the Algorand Platform
+ */
+export const _platform: "Algorand" = "Algorand";
+/**
+ * Compile time Type for the Algorand Platform
+ */
+export type AlgorandPlatformType = typeof _platform;
 
-export type AlgorandChains = PlatformToChains<"Algorand">;
+export type AlgorandChains = PlatformToChains<AlgorandPlatformType>;
 export type UniversalOrAlgorand = UniversalOrNative<AlgorandChains>;
 export type AnyAlgorandAddress = UniversalOrAlgorand | string | Uint8Array | bigint;
 

--- a/platforms/aptos/protocols/core/src/core.ts
+++ b/platforms/aptos/protocols/core/src/core.ts
@@ -19,7 +19,7 @@ import {
 import { AptosClient, Types } from "aptos";
 
 export class AptosWormholeCore<N extends Network, C extends AptosChains>
-  implements WormholeCore<N, AptosPlatformType, C>
+  implements WormholeCore<N, C>
 {
   readonly chainId: ChainId;
   readonly coreBridge: string;

--- a/platforms/aptos/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/aptos/protocols/tokenBridge/src/tokenBridge.ts
@@ -33,7 +33,7 @@ import { serializeForeignAddressSeeds } from "./foreignAddress";
 import { OriginInfo, TokenBridgeState } from "./types";
 
 export class AptosTokenBridge<N extends Network, C extends AptosChains>
-  implements TokenBridge<N, AptosPlatformType, C>
+  implements TokenBridge<N, C>
 {
   readonly chainId: ChainId;
 

--- a/platforms/aptos/src/chain.ts
+++ b/platforms/aptos/src/chain.ts
@@ -1,8 +1,4 @@
 import { ChainContext, Network } from "@wormhole-foundation/connect-sdk";
-import { AptosChains, AptosPlatformType } from "./types";
+import { AptosChains } from "./types";
 
-export class AptosChain<N extends Network, C extends AptosChains> extends ChainContext<
-  N,
-  AptosPlatformType,
-  C
-> {}
+export class AptosChain<N extends Network, C extends AptosChains> extends ChainContext<N, C> {}

--- a/platforms/cosmwasm/protocols/core/src/core.ts
+++ b/platforms/cosmwasm/protocols/core/src/core.ts
@@ -20,7 +20,7 @@ import {
 } from "@wormhole-foundation/connect-sdk-cosmwasm";
 
 export class CosmwasmWormholeCore<N extends Network, C extends CosmwasmChains>
-  implements WormholeCore<N, CosmwasmPlatformType, C>
+  implements WormholeCore<N, C>
 {
   private coreAddress: string;
 

--- a/platforms/cosmwasm/protocols/ibc/src/ibc.ts
+++ b/platforms/cosmwasm/protocols/ibc/src/ibc.ts
@@ -53,7 +53,7 @@ import { CosmwasmWormholeCore } from "@wormhole-foundation/connect-sdk-cosmwasm-
 const millisToNano = (seconds: number) => seconds * 1_000_000;
 
 export class CosmwasmIbcBridge<N extends Network, C extends CosmwasmChains>
-  implements IbcBridge<N, CosmwasmPlatformType, C>
+  implements IbcBridge<N, C>
 {
   private gatewayAddress: string;
 

--- a/platforms/cosmwasm/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/cosmwasm/protocols/tokenBridge/src/tokenBridge.ts
@@ -33,7 +33,7 @@ import {
 import "@wormhole-foundation/connect-sdk-cosmwasm-core";
 
 export class CosmwasmTokenBridge<N extends Network, C extends CosmwasmChains>
-  implements TokenBridge<N, CosmwasmPlatformType, C>
+  implements TokenBridge<N, C>
 {
   private tokenBridge: string;
   private translator?: string;

--- a/platforms/cosmwasm/src/chain.ts
+++ b/platforms/cosmwasm/src/chain.ts
@@ -1,7 +1,7 @@
 import { Chain, ChainContext, Network } from "@wormhole-foundation/connect-sdk";
-import { CosmwasmChains, CosmwasmPlatformType } from "./types";
+import { CosmwasmChains } from "./types";
 
 export class CosmwasmChain<
   N extends Network = Network,
   C extends Chain = CosmwasmChains,
-> extends ChainContext<N, CosmwasmPlatformType, C> {}
+> extends ChainContext<N, C> {}

--- a/platforms/cosmwasm/src/gateway.ts
+++ b/platforms/cosmwasm/src/gateway.ts
@@ -14,13 +14,9 @@ import {
 import { CosmwasmAddress } from "./address";
 import { IBC_TRANSFER_PORT } from "./constants";
 import { CosmwasmPlatform } from "./platform";
-import { CosmwasmChains, CosmwasmPlatformType } from "./types";
+import { CosmwasmChains } from "./types";
 
-export class Gateway<N extends Network> extends ChainContext<
-  N,
-  CosmwasmPlatformType,
-  typeof Gateway.chain
-> {
+export class Gateway<N extends Network> extends ChainContext<N, typeof Gateway.chain> {
   static chain: "Wormchain" = "Wormchain";
 
   static gatewayAddress = (network: Network): string =>

--- a/platforms/cosmwasm/src/platform.ts
+++ b/platforms/cosmwasm/src/platform.ts
@@ -51,6 +51,7 @@ export class CosmwasmPlatform<N extends Network>
   }
 
   getChain<C extends CosmwasmChains>(chain: C, rpc?: CosmWasmClient): CosmwasmChain<N, C> {
+    // @ts-ignore
     if (chain in this.config) return new CosmwasmChain<N, C>(chain, this, rpc);
     throw new Error("No configuration available for chain: " + chain);
   }

--- a/platforms/cosmwasm/src/platform.ts
+++ b/platforms/cosmwasm/src/platform.ts
@@ -51,7 +51,6 @@ export class CosmwasmPlatform<N extends Network>
   }
 
   getChain<C extends CosmwasmChains>(chain: C, rpc?: CosmWasmClient): CosmwasmChain<N, C> {
-    // @ts-ignore
     if (chain in this.config) return new CosmwasmChain<N, C>(chain, this, rpc);
     throw new Error("No configuration available for chain: " + chain);
   }

--- a/platforms/evm/protocols/cctp/src/automaticCircleBridge.ts
+++ b/platforms/evm/protocols/cctp/src/automaticCircleBridge.ts
@@ -21,7 +21,6 @@ import {
   EvmAddress,
   EvmChains,
   EvmPlatform,
-  EvmPlatformType,
   EvmUnsignedTransaction,
   addChainId,
   addFrom,
@@ -31,7 +30,7 @@ import '@wormhole-foundation/connect-sdk-evm-core';
 import '@wormhole-foundation/connect-sdk-evm-tokenbridge';
 
 export class EvmAutomaticCircleBridge<N extends Network, C extends EvmChains>
-  implements AutomaticCircleBridge<N, EvmPlatformType, C>
+  implements AutomaticCircleBridge<N, C>
 {
   readonly circleRelayer: CircleRelayer;
   readonly chainId: bigint;

--- a/platforms/evm/protocols/cctp/src/circleBridge.ts
+++ b/platforms/evm/protocols/cctp/src/circleBridge.ts
@@ -18,7 +18,6 @@ import {
   EvmAddress,
   EvmChains,
   EvmPlatform,
-  EvmPlatformType,
   EvmUnsignedTransaction,
   addChainId,
   addFrom,
@@ -28,7 +27,7 @@ import { ethers_contracts } from '.';
 //https://github.com/circlefin/evm-cctp-contracts
 
 export class EvmCircleBridge<N extends Network, C extends EvmChains>
-  implements CircleBridge<N, EvmPlatformType, C>
+  implements CircleBridge<N, C>
 {
   readonly chainId: bigint;
   readonly circleChainId: number;

--- a/platforms/evm/protocols/core/src/core.ts
+++ b/platforms/evm/protocols/core/src/core.ts
@@ -22,15 +22,10 @@ import {
   addChainId,
   addFrom,
 } from '@wormhole-foundation/connect-sdk-evm';
-import {
-  PlatformToChains,
-  nativeChainIds,
-} from '@wormhole-foundation/sdk-base';
+import { nativeChainIds } from '@wormhole-foundation/sdk-base';
 
-export class EvmWormholeCore<
-  N extends Network,
-  C extends PlatformToChains<EvmPlatformType>,
-> implements WormholeCore<N, EvmPlatformType, C>
+export class EvmWormholeCore<N extends Network, C extends EvmChains>
+  implements WormholeCore<N, C>
 {
   readonly chainId: bigint;
 

--- a/platforms/evm/protocols/portico/src/bridge.ts
+++ b/platforms/evm/protocols/portico/src/bridge.ts
@@ -37,7 +37,7 @@ import '@wormhole-foundation/connect-sdk-evm-tokenbridge';
 export class EvmPorticoBridge<
   N extends Network,
   C extends EvmChains = EvmChains,
-> implements PorticoBridge<N, 'Evm', C>
+> implements PorticoBridge<N, C>
 {
   chainId: bigint;
   porticoAddress: string;

--- a/platforms/evm/protocols/tokenBridge/src/automaticTokenBridge.ts
+++ b/platforms/evm/protocols/tokenBridge/src/automaticTokenBridge.ts
@@ -28,7 +28,7 @@ import { ethers_contracts } from '.';
 import '@wormhole-foundation/connect-sdk-evm-core';
 
 export class EvmAutomaticTokenBridge<N extends Network, C extends EvmChains>
-  implements AutomaticTokenBridge<N, EvmPlatformType, C>
+  implements AutomaticTokenBridge<N, C>
 {
   readonly tokenBridgeRelayer: ethers_contracts.TokenBridgeRelayer;
   readonly tokenBridge: ethers_contracts.TokenBridgeContract;

--- a/platforms/evm/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/evm/protocols/tokenBridge/src/tokenBridge.ts
@@ -1,24 +1,24 @@
 import {
   AccountAddress,
+  Chain,
   ChainAddress,
   ChainsConfig,
   Contracts,
   ErrNotWrapped,
   NativeAddress,
   Network,
+  Platform,
   TokenAddress,
   TokenBridge,
   TokenId,
   UniversalAddress,
+  isNative,
   keccak256,
+  nativeChainIds,
   serialize,
   toChain,
   toChainId,
-  Chain,
-  Platform,
-  nativeChainIds,
   toNative,
-  isNative,
 } from '@wormhole-foundation/connect-sdk';
 import { Provider, TransactionRequest } from 'ethers';
 
@@ -29,7 +29,6 @@ import {
   EvmAddress,
   EvmChains,
   EvmPlatform,
-  EvmPlatformType,
   EvmUnsignedTransaction,
   EvmZeroAddress,
   addChainId,
@@ -41,7 +40,7 @@ import {
 import '@wormhole-foundation/connect-sdk-evm-core';
 
 export class EvmTokenBridge<N extends Network, C extends EvmChains>
-  implements TokenBridge<N, EvmPlatformType, C>
+  implements TokenBridge<N, C>
 {
   readonly tokenBridge: TokenBridgeContract;
   readonly tokenBridgeAddress: string;

--- a/platforms/evm/src/chain.ts
+++ b/platforms/evm/src/chain.ts
@@ -1,5 +1,5 @@
 import { Chain, ChainContext, Network } from '@wormhole-foundation/connect-sdk';
-import { EvmChains, EvmPlatformType } from './types';
+import { EvmChains } from './types';
 
 /**
  * A ChainContext for the EVM platform
@@ -7,4 +7,4 @@ import { EvmChains, EvmPlatformType } from './types';
 export class EvmChain<
   N extends Network = Network,
   C extends Chain = EvmChains,
-> extends ChainContext<N, EvmPlatformType, C> {}
+> extends ChainContext<N, C> {}

--- a/platforms/evm/src/platform.ts
+++ b/platforms/evm/src/platform.ts
@@ -47,8 +47,6 @@ export class EvmPlatform<N extends Network>
   }
 
   getChain<C extends EvmChains>(chain: C, rpc?: Provider): EvmChain<N, C> {
-    // TODO
-    // @ts-ignore
     if (chain in this.config) return new EvmChain<N, C>(chain, this, rpc);
     throw new Error('No configuration available for chain: ' + chain);
   }

--- a/platforms/evm/src/platform.ts
+++ b/platforms/evm/src/platform.ts
@@ -27,7 +27,6 @@ import { AnyEvmAddress, EvmChains, EvmPlatformType, _platform } from './types';
 /**
  * @category EVM
  */
-
 export class EvmPlatform<N extends Network>
   extends PlatformContext<N, EvmPlatformType>
   implements StaticPlatformMethods<EvmPlatformType, typeof EvmPlatform>
@@ -48,7 +47,7 @@ export class EvmPlatform<N extends Network>
   }
 
   getChain<C extends EvmChains>(chain: C, rpc?: Provider): EvmChain<N, C> {
-    // @ts-ignore
+    //@ts-ignore
     if (chain in this.config) return new EvmChain<N, C>(chain, this, rpc);
     throw new Error('No configuration available for chain: ' + chain);
   }

--- a/platforms/evm/src/platform.ts
+++ b/platforms/evm/src/platform.ts
@@ -48,6 +48,7 @@ export class EvmPlatform<N extends Network>
   }
 
   getChain<C extends EvmChains>(chain: C, rpc?: Provider): EvmChain<N, C> {
+    // @ts-ignore
     if (chain in this.config) return new EvmChain<N, C>(chain, this, rpc);
     throw new Error('No configuration available for chain: ' + chain);
   }

--- a/platforms/evm/src/platform.ts
+++ b/platforms/evm/src/platform.ts
@@ -47,7 +47,8 @@ export class EvmPlatform<N extends Network>
   }
 
   getChain<C extends EvmChains>(chain: C, rpc?: Provider): EvmChain<N, C> {
-    //@ts-ignore
+    // TODO
+    // @ts-ignore
     if (chain in this.config) return new EvmChain<N, C>(chain, this, rpc);
     throw new Error('No configuration available for chain: ' + chain);
   }

--- a/platforms/solana/protocols/cctp/src/circleBridge.ts
+++ b/platforms/solana/protocols/cctp/src/circleBridge.ts
@@ -17,7 +17,6 @@ import {
   SolanaAddress,
   SolanaChains,
   SolanaPlatform,
-  SolanaPlatformType,
   SolanaTransaction,
   SolanaUnsignedTransaction,
 } from '@wormhole-foundation/connect-sdk-solana';
@@ -34,7 +33,7 @@ import {
 } from './utils/instructions';
 
 export class SolanaCircleBridge<N extends Network, C extends SolanaChains>
-  implements CircleBridge<N, SolanaPlatformType, C>
+  implements CircleBridge<N, C>
 {
   readonly tokenMessenger: Program<TokenMessenger>;
   readonly messageTransmitter: Program<MessageTransmitter>;

--- a/platforms/solana/protocols/core/src/core.ts
+++ b/platforms/solana/protocols/core/src/core.ts
@@ -9,15 +9,6 @@ import {
   VersionedTransactionResponse,
 } from '@solana/web3.js';
 import {
-  SolanaAddress,
-  AnySolanaAddress,
-  SolanaChains,
-  SolanaPlatform,
-  SolanaPlatformType,
-  SolanaUnsignedTransaction,
-  SolanaTransaction,
-} from '@wormhole-foundation/connect-sdk-solana';
-import {
   ChainId,
   ChainsConfig,
   Contracts,
@@ -29,22 +20,30 @@ import {
   WormholeMessageId,
   toChainId,
 } from '@wormhole-foundation/connect-sdk';
+import {
+  AnySolanaAddress,
+  SolanaAddress,
+  SolanaChains,
+  SolanaPlatform,
+  SolanaTransaction,
+  SolanaUnsignedTransaction,
+} from '@wormhole-foundation/connect-sdk-solana';
 import { Wormhole as WormholeCoreContract } from './types';
 import {
+  BridgeData,
+  createBridgeFeeTransferInstruction,
   createPostMessageInstruction,
   createPostVaaInstruction,
   createReadOnlyWormholeProgramInterface,
   createVerifySignaturesInstructions,
-  createBridgeFeeTransferInstruction,
   derivePostedVaaKey,
   getWormholeBridgeData,
-  BridgeData,
 } from './utils';
 
 const SOLANA_SEQ_LOG = 'Program log: Sequence: ';
 
 export class SolanaWormholeCore<N extends Network, C extends SolanaChains>
-  implements WormholeCore<N, SolanaPlatformType, C>
+  implements WormholeCore<N, C>
 {
   readonly chainId: ChainId;
   readonly coreBridge: Program<WormholeCoreContract>;

--- a/platforms/solana/protocols/tokenBridge/src/automaticTokenBridge.ts
+++ b/platforms/solana/protocols/tokenBridge/src/automaticTokenBridge.ts
@@ -1,5 +1,4 @@
 import {
-  Platform,
   AccountAddress,
   AutomaticTokenBridge,
   Chain,
@@ -8,6 +7,7 @@ import {
   ChainsConfig,
   Contracts,
   Network,
+  Platform,
   TokenAddress,
   isNative,
   toChainId,
@@ -17,7 +17,6 @@ import {
   SolanaAddress,
   SolanaChains,
   SolanaPlatform,
-  SolanaPlatformType,
   SolanaTransaction,
   SolanaUnsignedTransaction,
 } from '@wormhole-foundation/connect-sdk-solana';
@@ -55,7 +54,7 @@ const SWAP_RATE_PRECISION = new BN(100_000_000);
 export class SolanaAutomaticTokenBridge<
   N extends Network,
   C extends SolanaChains,
-> implements AutomaticTokenBridge<N, SolanaPlatformType, C>
+> implements AutomaticTokenBridge<N, C>
 {
   readonly chainId: ChainId;
 

--- a/platforms/solana/protocols/tokenBridge/src/tokenBridge.ts
+++ b/platforms/solana/protocols/tokenBridge/src/tokenBridge.ts
@@ -20,7 +20,6 @@ import {
   SolanaAddress,
   SolanaChains,
   SolanaPlatform,
-  SolanaPlatformType,
   SolanaTransaction,
   SolanaUnsignedTransaction,
 } from '@wormhole-foundation/connect-sdk-solana';
@@ -70,7 +69,7 @@ import {
 import '@wormhole-foundation/connect-sdk-solana-core';
 
 export class SolanaTokenBridge<N extends Network, C extends SolanaChains>
-  implements TokenBridge<N, SolanaPlatformType, C>
+  implements TokenBridge<N, C>
 {
   readonly chainId: ChainId;
 

--- a/platforms/solana/src/chain.ts
+++ b/platforms/solana/src/chain.ts
@@ -7,12 +7,12 @@ import {
   UniversalOrNative,
 } from '@wormhole-foundation/connect-sdk';
 import { SolanaAddress } from './address';
-import { SolanaChains, SolanaPlatformType } from './types';
+import { SolanaChains } from './types';
 
 export class SolanaChain<
   N extends Network,
   C extends SolanaChains = SolanaChains,
-> extends ChainContext<N, SolanaPlatformType, C> {
+> extends ChainContext<N, C> {
   override async getTokenAccount(
     address: UniversalOrNative<C>,
     token: UniversalOrNative<C>,

--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -66,6 +66,7 @@ export class SolanaPlatform<N extends Network>
     chain: C,
     rpc?: Connection,
   ): SolanaChain<N, C> {
+    // @ts-ignore
     if (chain in this.config) return new SolanaChain<N, C>(chain, this, rpc);
     throw new Error('No configuration available for chain: ' + chain);
   }

--- a/platforms/solana/src/platform.ts
+++ b/platforms/solana/src/platform.ts
@@ -66,7 +66,6 @@ export class SolanaPlatform<N extends Network>
     chain: C,
     rpc?: Connection,
   ): SolanaChain<N, C> {
-    // @ts-ignore
     if (chain in this.config) return new SolanaChain<N, C>(chain, this, rpc);
     throw new Error('No configuration available for chain: ' + chain);
   }


### PR DESCRIPTION
The specification of Platform along with Chain is redundant since the Platform should be derived from the chain.