### PR TITLE
Change WormholeNamespace back to Wormhole

### DIFF
--- a/core/definitions/src/address.ts
+++ b/core/definitions/src/address.ts
@@ -39,16 +39,16 @@ export interface Address {
 }
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     export interface PlatformToNativeAddressMapping {}
   }
 }
 
-export type MappedPlatforms = keyof WormholeNamespace.PlatformToNativeAddressMapping;
+export type MappedPlatforms = keyof Wormhole.PlatformToNativeAddressMapping;
 
 /** Utility type to map platform to its native address implementation */
 type GetNativeAddress<P extends Platform> = P extends MappedPlatforms
-  ? WormholeNamespace.PlatformToNativeAddressMapping[P]
+  ? Wormhole.PlatformToNativeAddressMapping[P]
   : never;
 
 /** An address that has been parsed into its Nativfe Address type */

--- a/core/definitions/src/payloads/automaticCircleBridge.ts
+++ b/core/definitions/src/payloads/automaticCircleBridge.ts
@@ -63,7 +63,7 @@ export const namedPayloads = [
 
 // factory registration:
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PayloadLiteralToLayoutMapping
       extends RegisterPayloadTypes<"AutomaticCircleBridge", typeof namedPayloads> {}
   }

--- a/core/definitions/src/payloads/automaticTokenBridge.ts
+++ b/core/definitions/src/payloads/automaticTokenBridge.ts
@@ -17,7 +17,7 @@ export const namedPayloads = [
 
 // factory registration:
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PayloadLiteralToLayoutMapping
       extends RegisterPayloadTypes<"AutomaticTokenBridge", typeof namedPayloads> {}
   }

--- a/core/definitions/src/payloads/bam.ts
+++ b/core/definitions/src/payloads/bam.ts
@@ -68,7 +68,7 @@ export const namedPayloads = [
 // factory registration:
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PayloadLiteralToLayoutMapping
       extends RegisterPayloadTypes<"BAM", typeof namedPayloads> {}
   }

--- a/core/definitions/src/payloads/circleBridge.ts
+++ b/core/definitions/src/payloads/circleBridge.ts
@@ -40,7 +40,7 @@ export const namedPayloads = [["Message", circleMessageLayout]] as const satisfi
 
 // factory registration:
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PayloadLiteralToLayoutMapping
       extends RegisterPayloadTypes<"CircleBridge", typeof namedPayloads> {}
   }

--- a/core/definitions/src/payloads/governance.ts
+++ b/core/definitions/src/payloads/governance.ts
@@ -226,7 +226,7 @@ const cctpPayloads = [
 
 // factory registration:
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PayloadLiteralToLayoutMapping
       extends RegisterPayloadTypes<"WormholeCore", typeof coreBridgePayloads>,
         RegisterPayloadTypes<"TokenBridge", typeof tokenBridgePayloads>,

--- a/core/definitions/src/payloads/portico.ts
+++ b/core/definitions/src/payloads/portico.ts
@@ -37,7 +37,7 @@ export const namedPayloads = [["Transfer", porticoFlagSetLayout]] as const satis
 
 // factory registration:
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PayloadLiteralToLayoutMapping
       extends RegisterPayloadTypes<"PorticoBridge", typeof namedPayloads> {}
   }

--- a/core/definitions/src/payloads/relayer.ts
+++ b/core/definitions/src/payloads/relayer.ts
@@ -85,7 +85,7 @@ const namedPayloads = [
 // factory registration:
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PayloadLiteralToLayoutMapping
       extends RegisterPayloadTypes<"Relayer", typeof namedPayloads> {}
   }

--- a/core/definitions/src/payloads/tokenBridge.ts
+++ b/core/definitions/src/payloads/tokenBridge.ts
@@ -73,7 +73,7 @@ export const namedPayloads = [
 // factory registration:
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PayloadLiteralToLayoutMapping
       extends RegisterPayloadTypes<"TokenBridge", typeof namedPayloads> {}
   }

--- a/core/definitions/src/protocol.ts
+++ b/core/definitions/src/protocol.ts
@@ -3,14 +3,14 @@ import { RpcConnection } from "./rpc";
 import { ChainsConfig } from "./types";
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     export interface ProtocolToPlatformMapping {}
   }
 }
 
 /** A string type representing the name of a protocol */
-export type ProtocolName = keyof WormholeNamespace.ProtocolToPlatformMapping;
-type MappedProtocolPlatforms = keyof WormholeNamespace.ProtocolToPlatformMapping[ProtocolName];
+export type ProtocolName = keyof Wormhole.ProtocolToPlatformMapping;
+type MappedProtocolPlatforms = keyof Wormhole.ProtocolToPlatformMapping[ProtocolName];
 
 export type EmptyPlatformMap<P extends Platform, PN extends ProtocolName> = Map<
   P,
@@ -22,7 +22,7 @@ export type ProtocolImplementation<
   PN extends ProtocolName,
 > = PN extends ProtocolName
   ? T extends MappedProtocolPlatforms
-    ? WormholeNamespace.ProtocolToPlatformMapping[PN][T]
+    ? Wormhole.ProtocolToPlatformMapping[PN][T]
     : any
   : never;
 

--- a/core/definitions/src/protocols/circleBridge.ts
+++ b/core/definitions/src/protocols/circleBridge.ts
@@ -21,7 +21,7 @@ import { ProtocolPayload, ProtocolVAA, payloadDiscriminator } from "../vaa";
 import { EmptyPlatformMap } from "../protocol";
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     export interface ProtocolToPlatformMapping {
       CircleBridge: EmptyPlatformMap<Platform, CircleBridge.ProtocolName>;
       AutomaticCircleBridge: EmptyPlatformMap<Platform, AutomaticCircleBridge.ProtocolName>;

--- a/core/definitions/src/protocols/core.ts
+++ b/core/definitions/src/protocols/core.ts
@@ -7,7 +7,7 @@ import { VAA } from "../vaa";
 import { EmptyPlatformMap } from "../protocol";
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     export interface ProtocolToPlatformMapping {
       WormholeCore: EmptyPlatformMap<Platform, "WormholeCore">;
     }

--- a/core/definitions/src/protocols/ibc.ts
+++ b/core/definitions/src/protocols/ibc.ts
@@ -15,7 +15,7 @@ import { UnsignedTransaction } from "../unsignedTransaction";
 import { EmptyPlatformMap } from "../protocol";
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     export interface ProtocolToPlatformMapping {
       IbcBridge: EmptyPlatformMap<Platform, "IbcBridge">;
     }

--- a/core/definitions/src/protocols/nftBridge.ts
+++ b/core/definitions/src/protocols/nftBridge.ts
@@ -2,7 +2,7 @@ import { Platform } from "@wormhole-foundation/sdk-base";
 import { EmptyPlatformMap } from "../protocol";
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     export interface ProtocolToPlatformMapping {
       NftBridge: EmptyPlatformMap<Platform, "NftBridge">;
     }

--- a/core/definitions/src/protocols/portico.ts
+++ b/core/definitions/src/protocols/portico.ts
@@ -15,7 +15,7 @@ import { UnsignedTransaction } from "../unsignedTransaction";
 import { ProtocolVAA } from "../vaa";
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     export interface ProtocolToPlatformMapping {
       PorticoBridge: EmptyPlatformMap<Platform, PorticoBridge.ProtocolName>;
     }

--- a/core/definitions/src/protocols/relayer.ts
+++ b/core/definitions/src/protocols/relayer.ts
@@ -5,7 +5,7 @@ import { Platform } from "@wormhole-foundation/sdk-base";
 import { EmptyPlatformMap } from "../protocol";
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     export interface ProtocolToPlatformMapping {
       Relayer: EmptyPlatformMap<Platform, "Relayer">;
     }

--- a/core/definitions/src/protocols/tokenBridge.ts
+++ b/core/definitions/src/protocols/tokenBridge.ts
@@ -16,7 +16,7 @@ import { EmptyPlatformMap } from "../protocol";
 export const ErrNotWrapped = (token: string) => new Error(`Token ${token} is not a wrapped asset`);
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     export interface ProtocolToPlatformMapping {
       TokenBridge: EmptyPlatformMap<Platform, TokenBridge.ProtocolName>;
       AutomaticTokenBridge: EmptyPlatformMap<Platform, AutomaticTokenBridge.ProtocolName>;

--- a/core/definitions/src/vaa/registration.ts
+++ b/core/definitions/src/vaa/registration.ts
@@ -7,18 +7,18 @@ import { Layout } from "@wormhole-foundation/sdk-base";
 //  payloads and their respective layouts in a single place (which, besides being a terrible code
 //  smell, would also prevent users of the SDK to register their own payload types!)
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     //effective type: Record<string, Layout>
     interface PayloadLiteralToLayoutMapping {}
   }
 }
 
-export type LayoutLiteral = keyof WormholeNamespace.PayloadLiteralToLayoutMapping & string;
+export type LayoutLiteral = keyof Wormhole.PayloadLiteralToLayoutMapping & string;
 
 export type PayloadLiteral = LayoutLiteral | "Uint8Array";
 
 export type LayoutOf<LL extends LayoutLiteral> = LL extends infer V extends LayoutLiteral
-  ? WormholeNamespace.PayloadLiteralToLayoutMapping[V]
+  ? Wormhole.PayloadLiteralToLayoutMapping[V]
   : never;
 
 //we aren't enforcing that Protocol is actually a protocol as to keep things user-extensible

--- a/platforms/algorand/src/address.ts
+++ b/platforms/algorand/src/address.ts
@@ -84,7 +84,7 @@ export class AlgorandAddress implements Address {
 }
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PlatformToNativeAddressMapping {
       // @ts-ignore
       Algorand: AlgorandAddress;

--- a/platforms/aptos/src/address.ts
+++ b/platforms/aptos/src/address.ts
@@ -88,7 +88,7 @@ export class AptosAddress implements Address {
 }
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PlatformToNativeAddressMapping {
       // @ts-ignore
       Aptos: AptosAddress;

--- a/platforms/cosmwasm/src/address.ts
+++ b/platforms/cosmwasm/src/address.ts
@@ -235,7 +235,7 @@ export class CosmwasmAddress implements Address {
 }
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PlatformToNativeAddressMapping {
       // @ts-ignore
       Cosmwasm: CosmwasmAddress;

--- a/platforms/evm/src/address.ts
+++ b/platforms/evm/src/address.ts
@@ -89,7 +89,7 @@ export class EvmAddress implements Address {
 }
 
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     interface PlatformToNativeAddressMapping {
       // @ts-ignore
       Evm: EvmAddress;

--- a/platforms/solana/src/address.ts
+++ b/platforms/solana/src/address.ts
@@ -63,7 +63,7 @@ export class SolanaAddress implements Address {
 // This is required to make `type Z = NativeAddress<"Solana">;` resolve to SolanaAddress
 // but outside this module it does _not_ resolve correctly
 declare global {
-  namespace WormholeNamespace {
+  namespace Wormhole {
     export interface PlatformToNativeAddressMapping {
       // @ts-ignore
       Solana: SolanaAddress;


### PR DESCRIPTION
I suspect this is the cause of certain errors around unregistered native addresses. 

Since we always import `Wormhole` but never `WormholeNamespace`, I _think_ the native addresses were never seen as registered/available