### PR TITLE
Ntt payloads and better custom payload specification mechanism

### DIFF
--- a/connect/src/protocols/cctpTransfer.ts
+++ b/connect/src/protocols/cctpTransfer.ts
@@ -250,7 +250,7 @@ export class CircleTransfer<N extends Network = Network>
   async initiateTransfer(signer: Signer): Promise<TxHash[]> {
     /*
         0) check that the current `state` is valid to call this (eg: state == Created)
-        1) get a token transfer transaction for the token bridge given the context  
+        1) get a token transfer transaction for the token bridge given the context
         2) sign it given the signer
         3) submit it to chain
         4) return transaction id

--- a/connect/src/protocols/gatewayTransfer.ts
+++ b/connect/src/protocols/gatewayTransfer.ts
@@ -291,7 +291,7 @@ export class GatewayTransfer<N extends Network = Network> implements WormholeTra
   async initiateTransfer(signer: Signer): Promise<TxHash[]> {
     /*
         0) Check current `state` is valid to call this (eg: state == Created)
-        1) Figure out where to call and issue transactions  
+        1) Figure out where to call and issue transactions
         2) Update state
         3) return transaction ids
     */

--- a/core/base/__tests__/layout.ts
+++ b/core/base/__tests__/layout.ts
@@ -27,7 +27,7 @@ const testLayout = [
   {
     name: "bytesDynamicCustomLayout",
     binary: "bytes",
-    custom: [
+    layout: [
       { name: "bytesDynamicSize", binary: "bytes", size: 4 },
       { name: "bytesDynamicLengthSize", binary: "bytes", lengthSize: 4 },
     ],
@@ -35,17 +35,17 @@ const testLayout = [
   {
     name: "bytesFixedItem",
     binary: "bytes",
-    custom: { binary: "uint", size: 1, custom: { to: 13, from: 1 } },
+    layout: { binary: "uint", size: 1, custom: { to: 13, from: 1 } },
   },
   {
     name: "bytesDynamicItem",
     binary: "bytes",
-    custom: { binary: "uint", size: 1 },
+    layout: { binary: "uint", size: 1 },
   },
   {
     name: "bytesFixedLayout",
     binary: "bytes",
-    custom: [
+    layout: [
       {
         name: "uintFixedCustom",
         binary: "uint",
@@ -58,7 +58,7 @@ const testLayout = [
   {
     name: "bytesMixedLayout",
     binary: "bytes",
-    custom: [
+    layout: [
       { name: "bytesFixedPrimitive", binary: "bytes", custom: new Uint8Array(4) },
       { name: "uintFixedCustom", binary: "uint", size: 1, custom: { to: 33, from: 1 } },
       { name: "uintDynamicPrimitive", binary: "uint", size: 1 },
@@ -74,11 +74,11 @@ const testLayout = [
     name: "arrayMixedLayout",
     binary: "array",
     lengthSize: 1,
-    layout: { binary: "bytes", custom: [
+    layout: [
       { name: "uintDynamicPrimitive", binary: "uint", size: 1 },
       { name: "uintFixedPrimitive", binary: "uint", size: 1, custom: 25 },
       { name: "bytesFixedPrimitive", binary: "bytes", custom: new Uint8Array(4) },
-    ]},
+    ],
   },
   {
     name: "switchMixed",
@@ -99,6 +99,7 @@ const testLayout = [
 
 // uncomment the following to "test" correct type resolution:
 // import { LayoutToType, FixedItemsOfLayout, DynamicItemsOfLayout } from "../src";
+// type LT = LayoutToType<typeof testLayout>;
 // type FixedItems = FixedItemsOfLayout<typeof testLayout>;
 // type FixedValues = LayoutToType<FixedItems>;
 // type DynamicItems = DynamicItemsOfLayout<typeof testLayout>;
@@ -174,21 +175,22 @@ describe("Layout tests", function () {
   });
 
   const fixedInt = { name: "fixedSignedInt", binary: "int", size: 2 } as const;
+  const fixedIntData = { fixedSignedInt: -257 };
 
   it("should correctly serialize and deserialize signed integers", function () {
     const layout = [fixedInt] as const;
-    const encoded = serializeLayout(layout, { fixedSignedInt: -257 });
+    const encoded = serializeLayout(layout, fixedIntData);
     expect(encoded).toEqual(new Uint8Array([0xfe, 0xff]));
     const decoded = deserializeLayout(layout, encoded);
-    expect(decoded).toEqual({ fixedSignedInt: -257 });
+    expect(decoded).toEqual(fixedIntData);
   });
 
   it("should correctly serialize and deserialize little endian signed integers", function () {
     const layout = [{...fixedInt, endianness: "little"}] as const;
-    const encoded = serializeLayout(layout, { fixedSignedInt: -257 });
+    const encoded = serializeLayout(layout, fixedIntData);
     expect(encoded).toEqual(new Uint8Array([0xff, 0xfe]));
     const decoded = deserializeLayout(layout, encoded);
-    expect(decoded).toEqual({ fixedSignedInt: -257 });
+    expect(decoded).toEqual(fixedIntData);
   });
 
   describe("Bitset tests", function () {

--- a/core/base/__tests__/layout.ts
+++ b/core/base/__tests__/layout.ts
@@ -10,86 +10,78 @@ import {
 } from "../src";
 
 const testLayout = [
-  { name: "fixedDirectPrimitive", binary: "uint", size: 1, custom: 3 },
+  { name: "uintFixedPrimitive", binary: "uint", size: 1, custom: 3 },
   {
-    name: "fixedDirectCustom",
+    name: "uintFixedCustom",
     binary: "uint",
     size: 1,
-    custom: { to: 42, from: 1 },
+    custom: { to: "fixedConverted", from: 1 },
   },
-  { name: "dynamicDirectPrimitive", binary: "uint", size: 1 },
+  { name: "uintDynamicPrimitive", binary: "uint", size: 1 },
   {
-    name: "dynamicDirectCustom",
+    name: "uintDynamicCustom",
     binary: "uint",
     size: 1,
     custom: { to: (val: number) => val + 1, from: (val: number) => val - 1 },
   },
   {
-    name: "someDynamicObject",
-    binary: "object",
-    layout: [
-      { name: "someDynamicBytes", binary: "bytes", size: 4 },
-      { name: "someDynamicLengthBytes", binary: "bytes", lengthSize: 4 },
+    name: "bytesDynamicCustomLayout",
+    binary: "bytes",
+    custom: [
+      { name: "bytesDynamicSize", binary: "bytes", size: 4 },
+      { name: "bytesDynamicLengthSize", binary: "bytes", lengthSize: 4 },
     ],
   },
   {
-    name: "objectWithOnlyFixed",
-    binary: "object",
-    layout: [
+    name: "bytesFixedItem",
+    binary: "bytes",
+    custom: { binary: "uint", size: 1, custom: { to: 13, from: 1 } },
+  },
+  {
+    name: "bytesDynamicItem",
+    binary: "bytes",
+    custom: { binary: "uint", size: 1 },
+  },
+  {
+    name: "bytesFixedLayout",
+    binary: "bytes",
+    custom: [
       {
-        name: "someFixedObjectUint",
+        name: "uintFixedCustom",
         binary: "uint",
         size: 1,
-        custom: { to: 13, from: 1 },
+        custom: { to: "fixedConverted", from: 1 },
       },
+      { name: "bytesFixedPrimitive", binary: "bytes", custom: new Uint8Array(4) },
     ],
   },
   {
-    name: "objectWithSomeFixed",
-    binary: "object",
-    layout: [
-      {
-        name: "someFixedBytes",
-        binary: "bytes",
-        custom: { to: new Uint8Array(4), from: new Uint8Array(4) },
-      },
-      {
-        name: "someFixedUint",
-        binary: "uint",
-        size: 1,
-        custom: { to: 33, from: 1 },
-      },
-      { name: "someDynamicUint", binary: "uint", size: 1 },
+    name: "bytesMixedLayout",
+    binary: "bytes",
+    custom: [
+      { name: "bytesFixedPrimitive", binary: "bytes", custom: new Uint8Array(4) },
+      { name: "uintFixedCustom", binary: "uint", size: 1, custom: { to: 33, from: 1 } },
+      { name: "uintDynamicPrimitive", binary: "uint", size: 1 },
     ],
   },
   {
-    name: "arrayWithOnlyFixed",
-    binary: "array",
-    lengthSize: 1,
-    layout: { binary: "uint", size: 1, custom: 12 },
-  },
-  {
-    name: "arrayWithSomeFixed",
-    binary: "array",
-    lengthSize: 1,
-    layout: { binary: "object", layout: [
-      { name: "someDynamicUint", binary: "uint", size: 1 },
-      { name: "someFixedUint", binary: "uint", size: 1, custom: 25 },
-      {
-        name: "someFixedBytes",
-        binary: "bytes",
-        custom: { to: new Uint8Array(4), from: new Uint8Array(4) },
-      },
-    ]},
-  },
-  {
-    name: "arrayWithOnlyDynamic",
+    name: "arrayDynamicItem",
     binary: "array",
     lengthSize: 1,
     layout: { binary: "uint", size: 1 },
   },
   {
-    name: "switchWithSomeFixed",
+    name: "arrayMixedLayout",
+    binary: "array",
+    lengthSize: 1,
+    layout: { binary: "bytes", custom: [
+      { name: "uintDynamicPrimitive", binary: "uint", size: 1 },
+      { name: "uintFixedPrimitive", binary: "uint", size: 1, custom: 25 },
+      { name: "bytesFixedPrimitive", binary: "bytes", custom: new Uint8Array(4) },
+    ]},
+  },
+  {
+    name: "switchMixed",
     binary: "switch",
     idSize: 2,
     layouts: [
@@ -115,35 +107,39 @@ const testLayout = [
 describe("Layout tests", function () {
 
   const completeValues = {
-    fixedDirectPrimitive: 3,
-    fixedDirectCustom: 42,
-    dynamicDirectPrimitive: 2,
-    dynamicDirectCustom: 4,
-    someDynamicObject: {
-      someDynamicBytes: new Uint8Array(4),
-      someDynamicLengthBytes: new Uint8Array(5),
+    uintFixedPrimitive: 3,
+    uintFixedCustom: "fixedConverted",
+    uintDynamicPrimitive: 2,
+    uintDynamicCustom: 4,
+    bytesDynamicCustomLayout: {
+      bytesDynamicSize: new Uint8Array(4),
+      bytesDynamicLengthSize: new Uint8Array(5),
     },
-    objectWithOnlyFixed: { someFixedObjectUint: 13 },
-    objectWithSomeFixed: {
-      someDynamicUint: 8,
-      someFixedBytes: new Uint8Array(4),
-      someFixedUint: 33,
+    bytesFixedItem: 13,
+    bytesDynamicItem: 3,
+    bytesFixedLayout: {
+      uintFixedCustom: "fixedConverted",
+      bytesFixedPrimitive: new Uint8Array(4),
     },
-    arrayWithOnlyFixed: [],
-    arrayWithSomeFixed: [
+    bytesMixedLayout: {
+      bytesFixedPrimitive: new Uint8Array(4),
+      uintFixedCustom: 33,
+      uintDynamicPrimitive: 4,
+    },
+    arrayDynamicItem: [1, 2, 3],
+    arrayMixedLayout: [
       {
-        someDynamicUint: 10,
-        someFixedUint: 25,
-        someFixedBytes: new Uint8Array(4),
+        uintDynamicPrimitive: 10,
+        uintFixedPrimitive: 25,
+        bytesFixedPrimitive: new Uint8Array(4),
       },
       {
-        someDynamicUint: 11,
-        someFixedUint: 25,
-        someFixedBytes: new Uint8Array(4),
+        uintDynamicPrimitive: 11,
+        uintFixedPrimitive: 25,
+        bytesFixedPrimitive: new Uint8Array(4),
       },
     ],
-    arrayWithOnlyDynamic: [14, 16],
-    switchWithSomeFixed: {
+    switchMixed: {
       id: 1,
       case1FixedUint: 4,
       case1DynamicUint: 18,
@@ -152,20 +148,22 @@ describe("Layout tests", function () {
 
   it("should correctly add fixed values", function () {
     const dynamicValues = {
-      dynamicDirectPrimitive: 2,
-      dynamicDirectCustom: 4,
-      someDynamicObject: {
-        someDynamicBytes: new Uint8Array(4),
-        someDynamicLengthBytes: new Uint8Array(5),
+      uintDynamicPrimitive: 2,
+      uintDynamicCustom: 4,
+      bytesDynamicCustomLayout: {
+        bytesDynamicSize: new Uint8Array(4),
+        bytesDynamicLengthSize: new Uint8Array(5),
       },
-      arrayWithOnlyFixed: [],
-      objectWithSomeFixed: { someDynamicUint: 8 },
-      arrayWithSomeFixed: [{ someDynamicUint: 10 }, { someDynamicUint: 11 }],
-      arrayWithOnlyDynamic: [14, 16],
-      switchWithOnlyFixed: {
-        customIdName: "case2",
+      bytesDynamicItem: 3,
+      bytesMixedLayout: {
+        uintDynamicPrimitive: 4,
       },
-      switchWithSomeFixed: {
+      arrayDynamicItem: [1, 2, 3],
+      arrayMixedLayout: [
+        { uintDynamicPrimitive: 10 },
+        { uintDynamicPrimitive: 11 },
+      ],
+      switchMixed: {
         id: 1,
         case1DynamicUint: 18,
       }
@@ -204,7 +202,7 @@ describe("Layout tests", function () {
 
     it("should correctly serialize and deserialize Bitset items with default size", function () {
       const bitset = bitsetItem(names);
-      
+
       const encoded = serializeLayout(bitset, converted);
       expect(encoded).toEqual(new Uint8Array([0x01, 0x09]));
       const decoded = deserializeLayout(bitset, encoded);
@@ -213,7 +211,7 @@ describe("Layout tests", function () {
 
     it("should correctly serialize and deserialize Bitset items with manual size", function () {
       const bitset = bitsetItem(names, 3);
-      
+
       const encoded = serializeLayout(bitset, converted);
       expect(encoded).toEqual(new Uint8Array([0x00, 0x01, 0x09]));
       const decoded = deserializeLayout(bitset, encoded);
@@ -221,7 +219,7 @@ describe("Layout tests", function () {
     });
   });
 
-  it("should serialize and deserialze correctly", function () {
+  it("should serialize and deserialize correctly", function () {
     const encoded = serializeLayout(testLayout, completeValues);
     const decoded = deserializeLayout(testLayout, encoded);
     expect(decoded).toEqual(completeValues);

--- a/core/base/src/utils/layout/deserialize.ts
+++ b/core/base/src/utils/layout/deserialize.ts
@@ -3,8 +3,6 @@ import {
   Layout,
   LayoutItem,
   LayoutToType,
-  FixedPrimitiveBytesLayoutItem,
-  FixedValueBytesLayoutItem,
   CustomConversion,
   NumSizeToPrimitive,
   NumType,
@@ -14,200 +12,196 @@ import {
   numberMaxSize,
 } from "./layout";
 
-import { checkUint8ArrayDeeplyEqual, checkNumEquals } from "./utils";
+import { isLayout, checkBytesTypeEqual, checkNumEquals, isFixedBytesConversion } from "./utils";
+
+//use to avoid excessively deep instantion errors when TypeScript is instantiating overly eagerly
+type AllowTypeCheckSkip<L extends Layout> = Layout extends L ? any : LayoutToType<L>;
 
 export function deserializeLayout<L extends Layout, B extends boolean = true>(
   layout: L,
-  encoded: Uint8Array,
-  offset?: number,
-  consumeAll?: B,
+  bytes: BytesType,
+  opts?: {
+    offset?: number,
+    end?: number,
+    consumeAll?: B,
+  },
 ) {
-  const [decoded, finalOffset] = internalDeserializeLayout(layout, encoded, offset ?? 0);
+  const encoded = {
+    bytes,
+    offset: opts?.offset ?? 0,
+    end: opts?.end ?? bytes.length,
+  };
+  const decoded = internalDeserializeLayout(layout, encoded);
 
-  if ((consumeAll ?? true) && finalOffset !== encoded.length)
-    throw new Error(`encoded data is longer than expected: ${encoded.length} > ${finalOffset}`);
+  if ((opts?.consumeAll ?? true) && encoded.offset !== encoded.end)
+    throw new Error(`encoded data is longer than expected: ${encoded.end} > ${encoded.offset}`);
 
   return (
-    consumeAll ?? true ? decoded : [decoded, finalOffset]
-  ) as B extends true ? LayoutToType<L> : readonly [LayoutToType<L>, number];
+    opts?.consumeAll ?? true ? decoded : [decoded, encoded.offset]
+  ) as B extends true ? AllowTypeCheckSkip<L> : readonly [AllowTypeCheckSkip<L>, number];
 }
 
-function internalDeserializeLayout(
-  layout: Layout,
-  encoded: Uint8Array,
+type BytesChunk = {
+  bytes: BytesType,
   offset: number,
-): readonly [any, number] {
+  end: number,
+};
+
+function updateOffset(encoded: BytesChunk, size: number) {
+  const newOffset = encoded.offset + size;
+  if (newOffset > encoded.end)
+    throw new Error(`chunk is shorter than expected: ${encoded.end} < ${newOffset}`);
+
+  encoded.offset = newOffset;
+}
+
+function internalDeserializeLayout(layout: Layout, encoded: BytesChunk): any {
   if (!Array.isArray(layout))
-    return deserializeLayoutItem(layout as LayoutItem, encoded, offset);
+    return deserializeLayoutItem(layout as LayoutItem, encoded);
 
   let decoded = {} as any;
   for (const item of layout)
     try {
-      [((item as any).omit ? {} : decoded)[item.name], offset] =
-        deserializeLayoutItem(item, encoded, offset);
+      ((item as any).omit ? {} : decoded)[item.name] = deserializeLayoutItem(item, encoded);
     }
     catch (e) {
       (e as Error).message = `when deserializing item '${item.name}': ${(e as Error).message}`;
       throw e;
     }
 
-  return [decoded, offset];
-}
-
-function updateOffset(
-  encoded: Uint8Array,
-  offset: number,
-  size: number
-): number {
-  const newOffset = offset + size;
-  if (newOffset > encoded.length)
-    throw new Error(`encoded data is shorter than expected: ${encoded.length} < ${newOffset}`);
-
-  return newOffset;
+  return decoded;
 }
 
 function deserializeNum<S extends number>(
-  encoded: Uint8Array,
-  offset: number,
-  bytes: S,
+  encoded: BytesChunk,
+  size: S,
   endianness: Endianness = "big",
   signed: boolean = false,
-): readonly [NumSizeToPrimitive<S>, number] {
+) {
   let val = 0n;
-  for (let i = 0; i < bytes; ++i)
-    val |= BigInt(encoded[offset + i]!) << BigInt(8 * (endianness === "big" ? bytes - i - 1 : i));
+  for (let i = 0; i < size; ++i)
+    val |= BigInt(encoded.bytes[encoded.offset + i]!)
+        << BigInt(8 * (endianness === "big" ? size - i - 1 : i));
 
   //check sign bit if value is indeed signed and adjust accordingly
-  if (signed && (encoded[offset + (endianness === "big" ? 0 : bytes - 1)]! & 0x80))
-    val -= 1n << BigInt(8 * bytes);
+  if (signed && (encoded.bytes[encoded.offset + (endianness === "big" ? 0 : size - 1)]! & 0x80))
+    val -= 1n << BigInt(8 * size);
 
-  return [
-    ((bytes > numberMaxSize) ? val : Number(val)) as NumSizeToPrimitive<S>,
-    updateOffset(encoded, offset, bytes)
-  ] as const;
+  updateOffset(encoded, size);
+
+  return ((size > numberMaxSize) ? val : Number(val)) as NumSizeToPrimitive<S>;
 }
 
-function deserializeLayoutItem(
-  item: LayoutItem,
-  encoded: Uint8Array,
-  offset: number,
-): readonly [any, number] {
+function deserializeLayoutItem(item: LayoutItem, encoded: BytesChunk): any {
   switch (item.binary) {
     case "int":
     case "uint": {
-      const [value, newOffset] =
-        deserializeNum(encoded, offset, item.size, item.endianness, item.binary === "int");
+      const value = deserializeNum(encoded, item.size, item.endianness, item.binary === "int");
 
-      if (isNumType(item.custom)) {
-        checkNumEquals(item.custom, value);
-        return [item.custom, newOffset];
+      const { custom } = item;
+      if (isNumType(custom)) {
+        checkNumEquals(custom, value);
+        return custom;
+      }
+      if (isNumType(custom?.from)) {
+        checkNumEquals(custom!.from, value);
+        return custom!.to;
       }
 
-      if (isNumType(item?.custom?.from)) {
-        checkNumEquals(item!.custom!.from, value);
-        return [item!.custom!.to, newOffset];
-      }
-
-      //narrowing to CustomConver<UintType, any> is a bit hacky here, since the true type
-      //  would be CustomConver<number, any> | CustomConver<bigint, any>, but then we'd have to
-      //  further tease that apart still for no real gain...
-      type narrowedCustom = CustomConversion<NumType, any>;
-      return [
-        item.custom !== undefined ? (item.custom as narrowedCustom).to(value) : value,
-        newOffset
-      ];
+      //narrowing to CustomConversion<UintType, any> is a bit hacky here, since the true type
+      //  would be CustomConversion<number, any> | CustomConversion<bigint, any>, but then we'd
+      //  have to further tease that apart still for no real gain...
+      return custom !== undefined ? (custom as CustomConversion<NumType, any>).to(value) : value;
     }
     case "bytes": {
-      let newOffset;
-      let fixedFrom;
-      let fixedTo;
-      if (item.custom !== undefined) {
-        if (isBytesType(item.custom))
-          fixedFrom = item.custom;
-        else if (isBytesType(item.custom.from)) {
-          fixedFrom = item.custom.from;
-          fixedTo = item.custom.to;
+      const expectedSize =
+        ("lengthSize" in item && item.lengthSize !== undefined)
+        ? deserializeNum(encoded, item.lengthSize, item.lengthEndianness)
+        : (item as {size?: number})?.size;
+
+      const { custom } = item;
+      if (isLayout(custom)) { //handle layout conversions
+        if (expectedSize === undefined)
+          return internalDeserializeLayout(custom, encoded);
+
+        const subChunk = {...encoded, end: encoded.offset + expectedSize};
+        updateOffset(encoded, expectedSize);
+        const ret = internalDeserializeLayout(custom, subChunk);
+        if (subChunk.offset !== subChunk.end)
+          throw new Error(
+            `read less data than expected: ${subChunk.offset - encoded.offset} < ${expectedSize}`
+          );
+        return ret;
+      }
+
+      { //handle fixed conversions
+        let fixedFrom;
+        let fixedTo;
+        if (isBytesType(custom))
+          fixedFrom = custom;
+        else if (isFixedBytesConversion(custom)) {
+          fixedFrom = custom.from;
+          fixedTo = custom.to;
+        }
+        if (fixedFrom !== undefined) {
+          const size = expectedSize ?? fixedFrom.length;
+          const value = encoded.bytes.slice(encoded.offset, encoded.offset + size);
+          checkBytesTypeEqual(fixedFrom, value);
+          updateOffset(encoded, size);
+          return fixedTo ?? fixedFrom;
         }
       }
 
-      if (fixedFrom !== undefined)
-        newOffset = updateOffset(encoded, offset, fixedFrom.length);
-      else {
-        item = item as
-          Exclude<typeof item, FixedPrimitiveBytesLayoutItem | FixedValueBytesLayoutItem>;
-        if ("size" in item && item.size !== undefined)
-          newOffset = updateOffset(encoded, offset, item.size);
-        else if ("lengthSize" in item && item.lengthSize !== undefined) {
-          let length;
-          [length, offset] =
-            deserializeNum(encoded, offset, item.lengthSize, item.lengthEndianness);
-          newOffset = updateOffset(encoded, offset, length);
-        }
-        else
-          newOffset = encoded.length;
-      }
+      //handle no or custom conversions
+      const start = encoded.offset;
+      const end = (expectedSize !== undefined) ? encoded.offset + expectedSize : encoded.end;
+      updateOffset(encoded, end - start);
 
-      const value = encoded.slice(offset, newOffset);
-      if (fixedFrom !== undefined) {
-        checkUint8ArrayDeeplyEqual(fixedFrom, value);
-        return [fixedTo ?? fixedFrom, newOffset];
-      }
-
-      type narrowedCustom = CustomConversion<BytesType, any>;
-      return [
-        item.custom !== undefined ? (item.custom as narrowedCustom).to(value) : value,
-        newOffset
-      ];
+      const value = encoded.bytes.slice(start, end);
+      return custom !== undefined ? (custom as CustomConversion<BytesType, any>).to(value) : value;
     }
     case "array": {
       let ret = [] as any[];
       const { layout } = item;
       const deserializeArrayItem = () => {
-        const [deserializedItem, newOffset] = internalDeserializeLayout(layout, encoded, offset);
+        const deserializedItem = internalDeserializeLayout(layout, encoded);
         ret.push(deserializedItem);
-        offset = newOffset;
       }
 
       let length = null;
-      if ("length" in item)
+      if ("length" in item && item.length !== undefined)
         length = item.length;
-      else if (item.lengthSize !== undefined)
-        [length, offset] =
-          deserializeNum(encoded, offset, item.lengthSize, item.lengthEndianness);
+      else if ("lengthSize" in item && item.lengthSize !== undefined)
+        length = deserializeNum(encoded, item.lengthSize, item.lengthEndianness);
 
       if (length !== null)
         for (let i = 0; i < length; ++i)
           deserializeArrayItem();
       else
-        while (offset < encoded.length)
+        while (encoded.offset < encoded.end)
           deserializeArrayItem();
 
-      return [ret, offset];
-    }
-    case "object": {
-      return internalDeserializeLayout(item.layout, encoded, offset);
+      return ret;
     }
     case "switch": {
-      const [id, newOffset] = deserializeNum(encoded, offset, item.idSize, item.idEndianness);
+      const id = deserializeNum(encoded, item.idSize, item.idEndianness);
       const {layouts} = item;
       if (layouts.length === 0)
         throw new Error(`switch item has no layouts`);
 
       const hasPlainIds = typeof layouts[0]![0] === "number";
-      const pair = (layouts as any[]).find(([idOrConversionId]) =>
+      const pair = (layouts as readonly any[]).find(([idOrConversionId]) =>
         hasPlainIds ? idOrConversionId === id : (idOrConversionId)[0] === id);
 
       if (pair === undefined)
         throw new Error(`unknown id value: ${id}`);
 
       const [idOrConversionId, idLayout] = pair;
-      const [decoded, nextOffset] = internalDeserializeLayout(idLayout, encoded, newOffset);
-      return [
-        { [item.idTag ?? "id"]: hasPlainIds ? id : (idOrConversionId as any)[1],
-          ...decoded
-        },
-        nextOffset
-      ];
+      const decoded = internalDeserializeLayout(idLayout, encoded);
+      return {
+        [item.idTag ?? "id"]: hasPlainIds ? id : (idOrConversionId as any)[1],
+        ...decoded
+      };
     }
   }
 }

--- a/core/base/src/utils/layout/fixedDynamic.ts
+++ b/core/base/src/utils/layout/fixedDynamic.ts
@@ -2,16 +2,19 @@ import {
   Layout,
   ProperLayout,
   LayoutItem,
-  LayoutItemBase,
-  NamedLayoutItem,
+  NumLayoutItem,
+  BytesLayoutItem,
+  ArrayLayoutItem,
   SwitchLayoutItem,
   LayoutToType,
-  PrimitiveType,
+  NumType,
+  BytesType,
+  LayoutObject,
   FixedConversion,
-  isPrimitiveType,
+  CustomConversion,
 } from "./layout";
 
-import { isLayout, isLayoutItem, isFixedConversion } from "./utils";
+import { isPrimitiveType, isLayoutItem, isFixedPrimitiveConversion } from "./utils";
 
 type NonEmpty = readonly [unknown, ...unknown[]];
 
@@ -28,27 +31,29 @@ type FilterItemsOfIPLPairs<ILA extends readonly IPLPair[], Fixed extends boolean
     : []
   : never;
 
-type GetLayout<I> =
-  I extends { layout: Layout }
-  ? I["layout"]
-  : I extends { custom: Layout }
-  ? I["custom"]
-  : never;
+type FilterLayoutOfItem<Item extends { layout: Layout }, Fixed extends boolean> =
+  FilterItemsOfLayout<Item["layout"], Fixed> extends infer L extends LayoutItem | NonEmpty
+  ? { readonly [K in keyof Item]: K extends "layout" ? L : Item[K] }
+  : void;
 
 type FilterItem<Item extends LayoutItem, Fixed extends boolean> =
   Item extends infer I extends LayoutItem
-  ? I extends { custom: PrimitiveType | FixedConversion<infer From extends PrimitiveType, infer To> }
-    ? Fixed extends true ? I : void
-    : I extends LayoutItemBase<"int" | "uint">
-    ? Fixed extends true ? void : I
-    : I extends LayoutItemBase<"array"> | (LayoutItemBase<"bytes"> & { custom: LayoutItem | NonEmpty })
-    ? FilterItemsOfLayout<GetLayout<I>, Fixed> extends infer L extends Layout | void
-      ? L extends LayoutItem | NonEmpty
-        ? { readonly [K in keyof I]: K extends "layout" | "custom" ? L : I[K] }
-        : void
-      : never
-    : I extends LayoutItemBase<"bytes">
-    ? Fixed extends true ? void : I
+  ? I extends NumLayoutItem
+    ? I["custom"] extends NumType | FixedConversion<infer From extends NumType, infer To>
+      ? Fixed extends true ? I : void
+      : Fixed extends true ? void : I
+    : I extends ArrayLayoutItem
+    ? FilterLayoutOfItem<I, Fixed>
+    : I extends BytesLayoutItem & { layout: Layout }
+    ? I["custom"] extends { custom: FixedConversion<infer From extends LayoutObject, infer To>}
+      ? Fixed extends true ? I : void
+      : I extends { custom: CustomConversion<infer From extends LayoutObject, infer To>}
+      ? Fixed extends true ? void : I
+      : FilterLayoutOfItem<I, Fixed>
+    : I extends BytesLayoutItem
+    ? I["custom"] extends BytesType | FixedConversion<infer From extends BytesType, infer To>
+      ? Fixed extends true ? I : void
+      : Fixed extends true ? void : I
     : I extends SwitchLayoutItem
     ? { readonly [K in keyof I]:
         K extends "layouts" ? FilterItemsOfIPLPairs<I["layouts"], Fixed> : I[K]
@@ -60,9 +65,9 @@ type FilterItemsOfLayout<L extends Layout, Fixed extends boolean> =
   L extends infer LI extends LayoutItem
   ? FilterItem<LI, Fixed>
   : L extends infer P extends ProperLayout
-  ? P extends readonly [infer H extends NamedLayoutItem, ...infer T extends ProperLayout]
+  ? P extends readonly [infer H extends LayoutItem, ...infer T extends ProperLayout]
     ? FilterItem<H, Fixed> extends infer NI
-      ? NI extends NamedLayoutItem
+      ? NI extends LayoutItem
         ? [NI, ...FilterItemsOfLayout<T, Fixed>]
         : FilterItemsOfLayout<T, Fixed>
       : never
@@ -78,19 +83,24 @@ function filterItem(item: LayoutItem, fixed: boolean): LayoutItem | null {
   switch (item.binary) {
     // @ts-ignore - fallthrough is intentional
     case "bytes": {
-      const { custom } = item;
-      if (isLayoutItem(custom)) {
-        return filterItem(custom, fixed) ?? null;
-      }
-      if (isLayout(custom)) {
-        const filteredItems = internalFilterItemsOfProperLayout(custom, fixed);
-        return (filteredItems.length > 0) ? { ...item, custom: filteredItems } : null;
+      if ("layout" in item) {
+        const { custom } = item;
+        if (custom === undefined) {
+          const { layout } = item;
+          if (isLayoutItem(layout))
+            return filterItem(layout, fixed);
+
+          const filteredItems = internalFilterItemsOfProperLayout(layout, fixed);
+          return (filteredItems.length > 0) ? { ...item, layout: filteredItems } : null;
+        }
+        const isFixedItem = typeof custom.from !== "function";
+        return (fixed && isFixedItem || !fixed && !isFixedItem) ? item : null;
       }
     }
     case "int":
     case "uint": {
       const { custom } = item;
-      const isFixedItem = isPrimitiveType(custom) || isFixedConversion(custom);
+      const isFixedItem = isPrimitiveType(custom) || isFixedPrimitiveConversion(custom);
       return (fixed && isFixedItem || !fixed && !isFixedItem) ? item : null;
     }
     case "array": {
@@ -115,7 +125,7 @@ function filterItem(item: LayoutItem, fixed: boolean): LayoutItem | null {
 function internalFilterItemsOfProperLayout(proper: ProperLayout, fixed: boolean): ProperLayout {
   return proper.reduce(
     (acc, item) => {
-      const filtered = filterItem(item, fixed) as NamedLayoutItem | null;
+      const filtered = filterItem(item, fixed) as ProperLayout[number] | null;
       return filtered !== null ? [...acc, filtered] : acc;
     },
     [] as ProperLayout
@@ -126,14 +136,14 @@ function internalFilterItemsOfLayout(layout: Layout, fixed: boolean): any {
   return (Array.isArray(layout)
     ? internalFilterItemsOfProperLayout(layout, fixed)
     : filterItem(layout as LayoutItem, fixed)
-   ) as any;
+   );
 }
 
 function filterItemsOfLayout<L extends Layout, const Fixed extends boolean>(
   layout: L,
   fixed: Fixed
 ): FilterItemsOfLayout<L, Fixed> {
-  return internalFilterItemsOfLayout(layout, fixed) as any;
+  return internalFilterItemsOfLayout(layout, fixed);
 }
 
 export type FixedItemsOfLayout<L extends Layout> = StartFilterItemsOfLayout<L, true>;
@@ -149,9 +159,13 @@ function internalAddFixedValuesItem(item: LayoutItem, dynamicValue: any): any {
   switch (item.binary) {
     // @ts-ignore - fallthrough is intentional
     case "bytes": {
-      const { custom } = item;
-      if (isLayout(custom))
-        return internalAddFixedValues(custom, dynamicValue);
+      if ("layout" in item) {
+        const { custom } = item;
+        if (custom === undefined || typeof custom.from !== "function")
+          return internalAddFixedValues(item.layout, custom ? custom.from : dynamicValue);
+
+        return dynamicValue;
+      }
     }
     case "int":
     case "uint": {
@@ -160,7 +174,7 @@ function internalAddFixedValuesItem(item: LayoutItem, dynamicValue: any): any {
         ? undefined
         : isPrimitiveType(custom)
         ? custom
-        : isFixedConversion(custom)
+        : isFixedPrimitiveConversion(custom)
         ? custom.to
         : dynamicValue;
     }
@@ -198,7 +212,7 @@ function internalAddFixedValues(layout: Layout, dynamicValues: any): any {
   return ret;
 }
 
-export function addFixedValues<L extends Layout>(
+export function addFixedValues<const L extends Layout>(
   layout: L,
   dynamicValues: LayoutToType<DynamicItemsOfLayout<L>>,
 ): LayoutToType<L> {

--- a/core/base/src/utils/layout/index.ts
+++ b/core/base/src/utils/layout/index.ts
@@ -1,28 +1,28 @@
 export {
   Layout,
+  ProperLayout,
   LayoutItem,
   NamedLayoutItem,
   NumLayoutItem,
+  BytesLayoutItem,
+  ArrayLayoutItem,
+  SwitchLayoutItem,
   IntLayoutItem,
   UintLayoutItem,
-  BytesLayoutItem,
   FixedPrimitiveNumLayoutItem,
   OptionalToFromNumLayoutItem,
   FixedPrimitiveBytesLayoutItem,
-  FixedValueBytesLayoutItem,
-  FixedSizeBytesLayoutItem,
+  ManualSizeBytesLayoutItem,
   LengthPrefixedBytesLayoutItem,
-  FixedSizeArrayLayoutItem,
+  FlexBytesLayoutItem,
+  FixedLengthArrayLayoutItem,
   LengthPrefixedArrayLayoutItem,
-  ArrayLayoutItem,
-  ObjectLayoutItem,
+  RemainderArrayLayoutItem,
   LayoutToType,
-  LayoutItemToType,
   FixedConversion,
   CustomConversion,
 } from "./layout";
 
-export { calcLayoutSize } from "./size";
 export { serializeLayout } from "./serialize";
 export { deserializeLayout } from "./deserialize";
 export {
@@ -35,4 +35,5 @@ export {
 
 export { layoutDiscriminator } from "./discriminate";
 
+export * from "./size";
 export * from "./items";

--- a/core/base/src/utils/layout/index.ts
+++ b/core/base/src/utils/layout/index.ts
@@ -2,22 +2,12 @@ export {
   Layout,
   ProperLayout,
   LayoutItem,
-  NamedLayoutItem,
   NumLayoutItem,
   BytesLayoutItem,
   ArrayLayoutItem,
   SwitchLayoutItem,
   IntLayoutItem,
   UintLayoutItem,
-  FixedPrimitiveNumLayoutItem,
-  OptionalToFromNumLayoutItem,
-  FixedPrimitiveBytesLayoutItem,
-  ManualSizeBytesLayoutItem,
-  LengthPrefixedBytesLayoutItem,
-  FlexBytesLayoutItem,
-  FixedLengthArrayLayoutItem,
-  LengthPrefixedArrayLayoutItem,
-  RemainderArrayLayoutItem,
   LayoutToType,
   FixedConversion,
   CustomConversion,
@@ -34,6 +24,7 @@ export {
 } from "./fixedDynamic";
 
 export { layoutDiscriminator } from "./discriminate";
+export { isLayout, isLayoutItem, CustomizableBytes, customizableBytes } from "./utils";
 
 export * from "./size";
 export * from "./items";

--- a/core/base/src/utils/layout/items.ts
+++ b/core/base/src/utils/layout/items.ts
@@ -34,7 +34,7 @@ export const bitsetItem = <
   const S extends number = BitsizeToBytesize<B["length"]>,
 >(bitnames: B, size?: S): BitsetItem<B, S> => ({
   binary: "uint",
-  size: size ?? Math.ceil(bitnames.length / 8) as unknown as S,
+  size: (size ?? Math.ceil(bitnames.length / 8)) as S,
   custom: {
     to: (encoded: NumSizeToPrimitive<S>): Bitset<B> => {
       const ret: Bitset<B> = {} as Bitset<B>;

--- a/core/base/src/utils/layout/layout.ts
+++ b/core/base/src/utils/layout/layout.ts
@@ -9,7 +9,8 @@ export type PrimitiveType = NumType | BytesType;
 export const isPrimitiveType = (x: any): x is PrimitiveType =>
   isNumType(x) || isBytesType(x);
 
-export type BinaryLiterals = "int" | "uint" | "bytes" | "array" | "object" | "switch";
+export const binaryLiterals = ["int", "uint", "bytes", "array", "switch"] as const;
+export type BinaryLiterals = typeof binaryLiterals[number];
 export type Endianness = "little" | "big"; //default is always big
 
 //Why only a max value of 2**(6*8)?
@@ -24,7 +25,11 @@ export type NumberSize = 1 | 2 | 3 | 4 | 5 | 6;
 export const numberMaxSize = 6;
 
 export type NumSizeToPrimitive<Size extends number> =
-  Size extends NumberSize ? number : bigint;
+  Size extends NumberSize
+  ? number
+  : Size & NumberSize extends never
+  ? bigint
+  : number | bigint;
 
 export type FixedConversion<FromType extends PrimitiveType, ToType> = {
   readonly to: ToType,
@@ -36,18 +41,24 @@ export type CustomConversion<FromType extends PrimitiveType, ToType> = {
   readonly from: (val: ToType) => FromType,
 };
 
-interface LayoutItemBase<BL extends BinaryLiterals> {
+export interface LayoutItemBase<BL extends BinaryLiterals> {
   readonly binary: BL,
 };
 
-interface FixedPrimitiveCustom<T extends PrimitiveType> {
+interface FixedOmittableCustom<T extends PrimitiveType> {
   custom: T,
   omit?: boolean
 };
 
-interface OptionalToFromCustom<T extends PrimitiveType> {
-  custom?: FixedConversion<T, any> | CustomConversion<T, any>
-};
+//length size: number of bytes used to encode the preceeding length field which in turn
+//  holds either the number of bytes (for bytes) or elements (for array)
+export interface LengthPrefixed {
+  readonly lengthSize: NumberSize,
+  readonly lengthEndianness?: Endianness, //default is big
+  // //restricts the datarange of lengthSize to a maximum value to prevent out of memory
+  // //  attacks/issues
+  // readonly maxLength?: number,
+}
 
 //size: number of bytes used to encode the item
 interface NumLayoutItemBase<T extends NumType, Signed extends Boolean>
@@ -56,49 +67,75 @@ interface NumLayoutItemBase<T extends NumType, Signed extends Boolean>
   endianness?: Endianness, //default is big
 };
 
-export interface FixedPrimitiveNumLayoutItem<T extends NumType, Signed extends Boolean>
-  extends NumLayoutItemBase<T, Signed>, FixedPrimitiveCustom<T> {};
+export interface FixedPrimitiveNumLayoutItem<
+  T extends NumType,
+  Signed extends Boolean
+> extends NumLayoutItemBase<T, Signed>, FixedOmittableCustom<T> {};
 
-export interface OptionalToFromNumLayoutItem<T extends NumType, Signed extends Boolean>
-  extends NumLayoutItemBase<T, Signed>, OptionalToFromCustom<T> {};
+export interface OptionalToFromNumLayoutItem<
+  T extends NumType,
+  Signed extends Boolean
+> extends NumLayoutItemBase<T, Signed> {
+  custom?: FixedConversion<T, any> | CustomConversion<T, any>
+};
 
 export interface FixedPrimitiveBytesLayoutItem
-  extends LayoutItemBase<"bytes">, FixedPrimitiveCustom<BytesType> {};
+  extends LayoutItemBase<"bytes">, FixedOmittableCustom<BytesType> {};
 
-export interface FixedValueBytesLayoutItem extends LayoutItemBase<"bytes"> {
-  readonly custom: FixedConversion<BytesType, any>,
+//A word on the somewhat confusing size, lengthSize, and custom properties of BytesLayouts:
+//  It is a common pattern that layouts define a certain structure, while also wanting to allow
+//    customization of certain portions of that structure. E.g. a layout might define a known,
+//    fixed header, followed by a body, which might be the rest of the data, or have some prefixed
+//    or even known, fixed size.
+//  A natural way to enable this sort of functionality is to specify a layout that contains a body
+//    LayoutItem with the given length/size fields, but with an overrideable custom field, where
+//    the generic version simply leaves custom unspecified resulting in an raw Uint8Array.
+//  Allowing such overriding can give somewhat confusing results thought:
+//  For example, if layouts are only ever defined by a single party, it would never make sense to
+//    specify both a size and a FixedConversion, since the former could be derived from the latter.
+//    But if multiple parties are involved, one party might want to nail down the size of the data
+//    itself, or the size and endianess of the length field, while another then specifies what the
+//    actual content is (and this might even be done recursively, where one protocol builds on
+//    top of another).
+//  So to facilitate this usecase, BytesLayouts allow for this sort of redundant specification.
+//
+//  One annoying downside of this approach is that it allows for inconsistent specifications.
+//  Following C++'s philosophy, we'll simple define the behavior as undefined in such cases.
+//  We could remedy the problem by providing a consistency check function, but this too is awkward
+//    because it would then perform what is effectively a verification of the code itself during
+//    every startup...
+//  Such are the perils of an interpreted language.
+//
+//Number of bytes written/read by a BytesLayout:
+//  If a size is specified manually, it must be consistent with the conversion or layout.
+//  If a lengthSize is specified, it will encode the size of the data on serialization, and
+//    must match the size of the conversion / layout on deserialization.
+//  If neither a size, nor a lengthSize is specified, and the size is not derivable from the custom
+//    property (i.e. it's undefined, or a CustomConversion, or a Layout whose size can't be
+//    statically determined), it will consume the rest of the data on deserialization.
+export interface FlexBytesLayoutItem extends LayoutItemBase<"bytes"> {
+  readonly custom?:
+    Layout | BytesType | FixedConversion<BytesType, any> | CustomConversion<BytesType, any>,
 };
 
-export interface FixedSizeBytesLayoutItem extends LayoutItemBase<"bytes"> {
+export interface ManualSizeBytesLayoutItem extends FlexBytesLayoutItem {
   readonly size: number,
-  readonly custom?: CustomConversion<BytesType, any>,
 };
 
-//length size: number of bytes used to encode the preceeding length field which in turn
-//  hold either the number of bytes (for bytes) or elements (for array)
-//  undefined means it will consume the rest of the data
-export interface LengthPrefixedBytesLayoutItem extends LayoutItemBase<"bytes"> {
-  readonly lengthSize?: NumberSize,
-  readonly lengthEndianness?: Endianness, //default is big
-  readonly custom?: CustomConversion<BytesType, any>,
-};
+export interface LengthPrefixedBytesLayoutItem extends FlexBytesLayoutItem, LengthPrefixed {};
 
 interface ArrayLayoutItemBase extends LayoutItemBase<"array"> {
   readonly layout: Layout,
 };
 
-export interface FixedSizeArrayLayoutItem extends ArrayLayoutItemBase {
+export interface FixedLengthArrayLayoutItem extends ArrayLayoutItemBase {
   readonly length: number,
 };
 
-export interface LengthPrefixedArrayLayoutItem extends ArrayLayoutItemBase {
-  readonly lengthSize?: NumberSize,
-  readonly lengthEndianness?: Endianness, //default is big
-};
+export interface LengthPrefixedArrayLayoutItem extends ArrayLayoutItemBase, LengthPrefixed {};
 
-export interface ObjectLayoutItem extends LayoutItemBase<"object"> {
-  readonly layout: ProperLayout,
-}
+//consumes the rest of the data on deserialization
+export interface RemainderArrayLayoutItem extends ArrayLayoutItemBase {};
 
 type PlainId = number;
 type ConversionId = readonly [number, unknown];
@@ -106,12 +143,14 @@ type IdProperLayoutPair<
   Id extends PlainId | ConversionId,
   P extends ProperLayout = ProperLayout
 > = readonly [Id, P];
+type AtLeast1<T> = readonly [T, ...T[]];
 type IdProperLayoutPairs =
-  readonly IdProperLayoutPair<PlainId>[] | readonly IdProperLayoutPair<ConversionId>[];
+  AtLeast1<IdProperLayoutPair<PlainId>> |
+  AtLeast1<IdProperLayoutPair<ConversionId>>;
 export interface SwitchLayoutItem extends LayoutItemBase<"switch"> {
   readonly idSize: NumberSize,
-  readonly idTag?: string,
   readonly idEndianness?: Endianness, //default is big
+  readonly idTag?: string,
   readonly layouts: IdProperLayoutPairs,
 }
 
@@ -128,15 +167,17 @@ export type UintLayoutItem = NumLayoutItem<false>;
 export type IntLayoutItem = NumLayoutItem<true>;
 export type BytesLayoutItem =
   FixedPrimitiveBytesLayoutItem |
-  FixedValueBytesLayoutItem |
-  FixedSizeBytesLayoutItem |
+  FlexBytesLayoutItem |
+  ManualSizeBytesLayoutItem |
   LengthPrefixedBytesLayoutItem;
-export type ArrayLayoutItem = FixedSizeArrayLayoutItem | LengthPrefixedArrayLayoutItem;
+export type ArrayLayoutItem =
+  FixedLengthArrayLayoutItem |
+  LengthPrefixedArrayLayoutItem |
+  RemainderArrayLayoutItem;
 export type LayoutItem =
   NumLayoutItem |
   BytesLayoutItem |
   ArrayLayoutItem |
-  ObjectLayoutItem |
   SwitchLayoutItem;
 export type NamedLayoutItem = LayoutItem & { readonly name: string };
 export type ProperLayout = readonly NamedLayoutItem[];
@@ -168,27 +209,39 @@ type IdLayoutPairsToTypeUnion<A extends IdProperLayoutPairs, IdTag extends strin
     : never
   : never;
 
-export type LayoutItemToType<Item extends LayoutItem> =
+type LayoutItemToType<Item extends LayoutItem> =
   Item extends infer I extends LayoutItem
-  ? I extends NumLayoutItem
-    ? I["custom"] extends NumType
+  ? I extends LayoutItemBase<"int" | "uint">
+    ? I["custom"] extends undefined
+      ? NumSizeToPrimitive<I["size"]>
+      : I["custom"] extends NumType
       ? I["custom"]
+      //we must infer FromType here to make sure we "hit" the correct type of the Conversion
       : I["custom"] extends CustomConversion<infer FromType extends NumType, infer ToType>
       ? ToType
       : I["custom"] extends FixedConversion<infer FromType extends NumType, infer ToType>
       ? ToType
       : NumSizeToPrimitive<I["size"]>
-    : I extends BytesLayoutItem
-    ? I["custom"] extends CustomConversion<BytesType, infer ToType>
+    : I extends LayoutItemBase<"bytes">
+    ? I["custom"] extends undefined
+      ? BytesType
+      : I["custom"] extends Layout
+      ? LayoutToType<I["custom"]>
+      : I["custom"] extends CustomConversion<BytesType, infer ToType>
       ? ToType
       : I["custom"] extends FixedConversion<BytesType, infer ToType>
       ? ToType
-      : BytesType //this also covers FixedValueBytesLayoutItem (Uint8Arrays don't support literals)
-    : I extends ArrayLayoutItem
+      : BytesType
+    : I extends LayoutItemBase<"array">
     ? readonly LayoutToType<I["layout"]>[]
-    : I extends ObjectLayoutItem
-    ? LayoutToType<I["layout"]>
-    : I extends SwitchLayoutItem
-    ? IdLayoutPairsToTypeUnion<I["layouts"], I["idTag"] extends string ? I["idTag"] : "id">
+    : I extends LayoutItemBase<"switch">
+    ? IdLayoutPairsToTypeUnion<
+      I["layouts"],
+      I["idTag"] extends undefined
+      ? "id"
+      : I["idTag"] extends string
+      ? I["idTag"]
+      : never
+    >
     : never
   : never;

--- a/core/base/src/utils/layout/serialize.ts
+++ b/core/base/src/utils/layout/serialize.ts
@@ -3,44 +3,60 @@ import {
   Layout,
   LayoutItem,
   LayoutToType,
-  FixedPrimitiveBytesLayoutItem,
-  FixedValueBytesLayoutItem,
   CustomConversion,
   NumType,
+  BytesType,
   isNumType,
   isBytesType,
   numberMaxSize,
 } from "./layout";
 import { calcLayoutSize } from "./size";
 import {
-  checkUint8ArrayDeeplyEqual,
-  checkUint8ArraySize,
+  checkItemSize,
+  checkBytesTypeEqual,
   checkNumEquals,
-  findIdLayoutPair
+  findIdLayoutPair,
+  isFixedBytesConversion,
+  isLayout,
+  isLayoutItem,
 } from "./utils";
 
-export function serializeLayout<L extends Layout, E extends Uint8Array | undefined = undefined>(
+type Cursor = {
+  bytes: BytesType;
+  offset: number;
+};
+
+const cursorWrite = (cursor: Cursor, bytes: BytesType) => {
+  cursor.bytes.set(bytes, cursor.offset);
+  cursor.offset += bytes.length;
+}
+
+export function serializeLayout<L extends Layout, E extends BytesType | undefined = undefined>(
   layout: L,
   data: LayoutToType<L>,
   encoded?: E,
   offset = 0,
 ) {
-  return (
-    internalSerializeLayout(layout, data, encoded, offset)
-  ) as E extends undefined ? Uint8Array : number;
+  const cursor = {bytes: encoded ?? new Uint8Array(calcLayoutSize(layout, data)), offset};
+  internalSerializeLayout(layout, data, cursor);
+  if (!encoded && cursor.offset !== cursor.bytes.length)
+    throw new Error(
+      `encoded data is shorter than expected: ${cursor.bytes.length} > ${cursor.offset}`
+    );
+
+  return (encoded ? cursor.offset : cursor.bytes) as E extends undefined ? Uint8Array : number;
 }
 
 //see numberMaxSize comment in layout.ts
 const maxAllowedNumberVal = 2 ** (numberMaxSize * 8);
 
 export function serializeNum(
-  encoded: Uint8Array,
-  offset: number,
   val: NumType,
-  bytes: number,
+  size: number,
+  cursor: Cursor,
   endianness: Endianness = "big",
   signed: boolean = false,
-): number {
+) {
   if (!signed && val < 0)
     throw new Error(`Value ${val} is negative but unsigned`);
 
@@ -48,7 +64,7 @@ export function serializeNum(
     if (!Number.isInteger(val))
       throw new Error(`Value ${val} is not an integer`);
 
-    if (bytes > numberMaxSize) {
+    if (size > numberMaxSize) {
       if (val >= maxAllowedNumberVal)
         throw new Error(`Value ${val} is too large to be safely converted into an integer`);
 
@@ -57,62 +73,40 @@ export function serializeNum(
     }
   }
 
-  const bound = 2n ** BigInt(bytes * 8)
+  const bound = 2n ** BigInt(size * 8)
   if (val >= bound)
-    throw new Error(`Value ${val} is too large for ${bytes} bytes`);
+    throw new Error(`Value ${val} is too large for ${size} bytes`);
 
   if (signed && val < -bound)
-    throw new Error(`Value ${val} is too small for ${bytes} bytes`);
+    throw new Error(`Value ${val} is too small for ${size} bytes`);
 
   //correctly handles both signed and unsigned values
-  for (let i = 0; i < bytes; ++i)
-    encoded[offset + i] =
-      Number((BigInt(val) >> BigInt(8 * (endianness === "big" ? bytes - i - 1 : i)) & 0xffn));
+  for (let i = 0; i < size; ++i)
+    cursor.bytes[cursor.offset + i] =
+      Number((BigInt(val) >> BigInt(8 * (endianness === "big" ? size - i - 1 : i)) & 0xffn));
 
-  return offset + bytes;
+  cursor.offset += size;
 }
 
 function internalSerializeLayout(
   layout: Layout,
   data: any,
-): Uint8Array;
-
-function internalSerializeLayout(
-  layout: Layout,
-  data: any,
-  encoded?: Uint8Array,
-  offset?: number,
-): number;
-
-function internalSerializeLayout(
-  layout: Layout,
-  data: any,
-  encoded?: Uint8Array,
-  offset = 0,
-): Uint8Array | number {
-  let ret = encoded ?? new Uint8Array(calcLayoutSize(layout, data));
-  if (Array.isArray(layout))
-    for (let i = 0; i < layout.length; ++i)
+  cursor: Cursor,
+) {
+  if (isLayoutItem(layout))
+    serializeLayoutItem(layout as LayoutItem, data, cursor);
+  else
+    for (const item of layout)
       try {
-        offset =
-          serializeLayoutItem(layout[i], data[layout[i].name as keyof typeof data], ret, offset);
+        serializeLayoutItem(item, data[item.name], cursor);
       }
       catch (e: any) {
-        e.message = `when serializing item '${layout[i].name}': ${e.message}`;
+        e.message = `when serializing item '${item.name}': ${e.message}`;
         throw e;
       }
-  else
-    offset = serializeLayoutItem(layout as LayoutItem, data, ret, offset);
-
-  return encoded === undefined ? ret : offset;
 }
 
-function serializeLayoutItem(
-  item: LayoutItem,
-  data: any,
-  encoded: Uint8Array,
-  offset: number
-): number {
+function serializeLayoutItem(item: LayoutItem, data: any, cursor: Cursor) {
   switch (item.binary) {
     case "int":
     case "uint": {
@@ -131,36 +125,39 @@ function serializeLayoutItem(
         return item.custom !== undefined ? (item.custom as narrowedCustom).from(data) : data;
       })();
 
-      offset =
-        serializeNum(encoded, offset, value, item.size, item.endianness, item.binary === "int");
+      serializeNum(value, item.size, cursor, item.endianness, item.binary === "int");
       break;
     }
     case "bytes": {
-      const value = (() => {
-        if (isBytesType(item.custom)) {
-          if (!("omit" in item && item.omit))
-            checkUint8ArrayDeeplyEqual(item.custom, data);
-          return item.custom;
-        }
+      const offset = cursor.offset;
+      if ("lengthSize" in item && item.lengthSize !== undefined)
+        cursor.offset += item.lengthSize;
 
-        if (isBytesType(item?.custom?.from))
-          //no proper way to deeply check equality of item.custom.to and data in JS
-          return item!.custom!.from;
+      const { custom } = item;
+      if (isBytesType(custom)) {
+        if (!("omit" in item && item.omit))
+          checkBytesTypeEqual(custom, data);
 
-        item = item as
-          Exclude<typeof item, FixedPrimitiveBytesLayoutItem | FixedValueBytesLayoutItem>;
-        const ret = item.custom !== undefined ? item.custom.from(data) : data;
-        if ("size" in item && item.size !== undefined)
-          checkUint8ArraySize(ret, item.size);
-        else if ("lengthSize" in item && item.lengthSize !== undefined)
-          offset =
-            serializeNum(encoded, offset, ret.length, item.lengthSize, item.lengthEndianness);
+        cursorWrite(cursor, custom);
+      }
+      else if (isFixedBytesConversion(custom))
+        //no proper way to deeply check equality of custom.to and data
+        cursorWrite(cursor, custom.from);
+      else if (isLayout(custom))
+        internalSerializeLayout(custom, data, cursor);
+      else
+        cursorWrite(cursor, custom !== undefined ? custom.from(data) : data);
 
-        return ret;
-      })();
+      if ("lengthSize" in item && item.lengthSize !== undefined) {
+        const itemSize = cursor.offset - offset - item.lengthSize;
+        const curOffset = cursor.offset;
+        cursor.offset = offset;
+        serializeNum(itemSize, item.lengthSize, cursor, item.lengthEndianness);
+        cursor.offset = curOffset;
+      }
+      else
+        checkItemSize(item, cursor.offset - offset);
 
-      encoded.set(value, offset);
-      offset += value.length;
       break;
     }
     case "array": {
@@ -170,25 +167,19 @@ function serializeLayoutItem(
         );
 
       if ("lengthSize" in item && item.lengthSize !== undefined)
-        offset =
-          serializeNum(encoded, offset, data.length, item.lengthSize, item.lengthEndianness);
+        serializeNum(data.length, item.lengthSize, cursor, item.lengthEndianness);
 
       for (let i = 0; i < data.length; ++i)
-        offset = internalSerializeLayout(item.layout, data[i], encoded, offset);
+        internalSerializeLayout(item.layout, data[i], cursor);
 
-      break;
-    }
-    case "object": {
-      offset = internalSerializeLayout(item.layout, data, encoded, offset);
       break;
     }
     case "switch": {
       const [idOrConversionId, layout] = findIdLayoutPair(item, data);
       const idNum = (Array.isArray(idOrConversionId) ? idOrConversionId[0] : idOrConversionId);
-      offset = serializeNum(encoded, offset, idNum, item.idSize, item.idEndianness);
-      offset = internalSerializeLayout(layout, data, encoded, offset);
+      serializeNum(idNum, item.idSize, cursor, item.idEndianness);
+      internalSerializeLayout(layout, data, cursor);
       break;
     }
   }
-  return offset;
 };

--- a/core/base/src/utils/layout/utils.ts
+++ b/core/base/src/utils/layout/utils.ts
@@ -1,12 +1,23 @@
 import {
   Layout,
   LayoutItem,
+  BytesLayoutItem,
   SwitchLayoutItem,
   FixedConversion,
+  CustomConversion,
+  NumType,
   BytesType,
+  PrimitiveType,
   binaryLiterals,
-  isBytesType
 } from "./layout";
+
+export const isNumType = (x: any): x is NumType =>
+  typeof x === "number" || typeof x === "bigint";
+
+export const isBytesType = (x: any): x is BytesType => x instanceof Uint8Array;
+
+export const isPrimitiveType = (x: any): x is PrimitiveType =>
+  isNumType(x) || isBytesType(x);
 
 export const isLayoutItem = (x: any): x is LayoutItem => binaryLiterals.includes(x?.binary);
 
@@ -26,9 +37,62 @@ export const isFixedUintConversion = (custom: any): custom is
 export const isFixedBytesConversion = (custom: any): custom is FixedConversion<BytesType, any> =>
   isBytesType(custom?.from);
 
-export const isFixedConversion = (custom: any): custom is
+export const isFixedPrimitiveConversion = (custom: any): custom is
     FixedConversion<number, any> | FixedConversion<bigint, any> | FixedConversion<BytesType, any> =>
   isFixedUintConversion(custom) || isFixedBytesConversion(custom);
+
+export type CustomizableBytes =
+  undefined |
+  Layout |
+  Uint8Array |
+  FixedConversion<Uint8Array, any> |
+  CustomConversion<Uint8Array, any> |
+  readonly [Layout, FixedConversion<any, any> | CustomConversion<any, any>];
+
+type CombineObjects<T, U> = {
+  [K in keyof T | keyof U]: K extends keyof T ? T[K] : K extends keyof U ? U[K] : never;
+};
+
+type BytesBase = { readonly name: string } & Omit<BytesLayoutItem, "binary" | "custom" | "layout">;
+
+type CustomizableBytesReturn<B extends BytesBase, P extends CustomizableBytes> =
+  CombineObjects<
+    B,
+    P extends undefined
+    ? { readonly binary: "bytes" }
+    : P extends Layout
+    ? { readonly binary: "bytes", readonly layout: P }
+    : P extends Uint8Array |
+                FixedConversion<Uint8Array, infer To> |
+                CustomConversion<Uint8Array, infer To>
+    ? { readonly binary: "bytes", readonly custom: P }
+    : P extends readonly [
+        Layout,
+        FixedConversion<infer From, infer To> | CustomConversion<infer From, infer To>
+      ]
+    ? { readonly binary: "bytes", readonly layout: P[0], readonly custom: P[1] }
+    : never
+  >;
+
+export const customizableBytes = <
+  const B extends BytesBase,
+  const C extends CustomizableBytes
+>(base: B, spec?: C) => ({
+  ...base,
+  binary: "bytes",
+  ...(() => {
+    if (spec === undefined)
+      return {};
+
+    if (isLayout(spec))
+      return { layout: spec };
+
+    if (spec instanceof Uint8Array || isFixedBytesConversion(spec) || !Array.isArray(spec))
+      return { custom: spec };
+
+    return { layout: spec[0], custom: spec[1] };
+  })()
+} as CustomizableBytesReturn<B, C>);
 
 export const checkSize = (layoutSize: number, dataSize: number): number => {
   if (layoutSize !== dataSize)
@@ -45,12 +109,30 @@ export const checkNumEquals = (custom: number | bigint, data: number | bigint): 
     throw new Error(`value mismatch: (constant) layout value: ${custom}, data value: ${data}`);
 }
 
-export const checkBytesTypeEqual = (custom: BytesType, data: BytesType): void => {
-  checkSize(custom.length, data.length);
+export const checkBytesTypeEqual = (
+  custom: BytesType,
+  data: BytesType,
+  opts?: {
+    customSlice?: number | readonly [number, number];
+    dataSlize?: number | readonly [number, number];
+  }): void => {
+  const toSlice = (bytes: BytesType, slice?: number | readonly [number, number]) =>
+    slice === undefined
+      ? [0, bytes.length] as const
+      : Array.isArray(slice)
+      ? slice
+      : [slice, bytes.length] as const;
+
+  const [customStart, customEnd] = toSlice(custom, opts?.customSlice);
+  const [dataStart, dataEnd] = toSlice(data, opts?.dataSlize);
+  const length = customEnd - customStart;
+  checkSize(length, dataEnd - dataStart);
 
   for (let i = 0; i < custom.length; ++i)
-    if (custom[i] !== data[i])
-      throw new Error(`binary data mismatch: layout value: ${custom}, data value: ${data}`);
+    if (custom[i + customStart] !== data[i + dataStart])
+      throw new Error(`binary data mismatch: ` +
+        `layout value: ${custom}, offset: ${customStart}, data value: ${data}, offset: ${dataStart}`
+      );
 }
 
 export function findIdLayoutPair(item: SwitchLayoutItem, data: any) {

--- a/core/base/src/utils/layout/utils.ts
+++ b/core/base/src/utils/layout/utils.ts
@@ -1,45 +1,61 @@
-import { BytesLayoutItem, SwitchLayoutItem, isBytesType } from "./layout";
+import {
+  Layout,
+  LayoutItem,
+  SwitchLayoutItem,
+  FixedConversion,
+  BytesType,
+  binaryLiterals,
+  isBytesType
+} from "./layout";
 
-export const checkUint8ArraySize = (custom: Uint8Array, size: number): void => {
-  if (custom.length !== size)
-    throw new Error(
-      `binary size mismatch: layout size: ${custom.length}, data size: ${size}`
-    );
+export const isLayoutItem = (x: any): x is LayoutItem => binaryLiterals.includes(x?.binary);
+
+export const isLayout = (x: any): x is Layout =>
+  isLayoutItem(x) || Array.isArray(x) && x.every(isLayoutItem);
+
+const isFixedNumberConversion = (custom: any): custom is FixedConversion<number, any> =>
+  typeof custom?.from === "number";
+
+const isFixedBigintConversion = (custom: any): custom is FixedConversion<bigint, any> =>
+  typeof custom?.from === "bigint";
+
+export const isFixedUintConversion = (custom: any): custom is
+    FixedConversion<number, any> | FixedConversion<bigint, any> =>
+  isFixedNumberConversion(custom) || isFixedBigintConversion(custom);
+
+export const isFixedBytesConversion = (custom: any): custom is FixedConversion<BytesType, any> =>
+  isBytesType(custom?.from);
+
+export const isFixedConversion = (custom: any): custom is
+    FixedConversion<number, any> | FixedConversion<bigint, any> | FixedConversion<BytesType, any> =>
+  isFixedUintConversion(custom) || isFixedBytesConversion(custom);
+
+export const checkSize = (layoutSize: number, dataSize: number): number => {
+  if (layoutSize !== dataSize)
+    throw new Error(`size mismatch: layout size: ${layoutSize}, data size: ${dataSize}`);
+
+  return dataSize;
 }
+
+export const checkItemSize = (item: any, dataSize: number): number =>
+  ("size" in item && item.size !== undefined) ? checkSize(item.size, dataSize) : dataSize;
 
 export const checkNumEquals = (custom: number | bigint, data: number | bigint): void => {
   if (custom != data)
-    throw new Error(
-      `value mismatch: (constant) layout value: ${custom}, data value: ${data}`
-    );
+    throw new Error(`value mismatch: (constant) layout value: ${custom}, data value: ${data}`);
 }
 
-export const checkUint8ArrayDeeplyEqual = (custom: Uint8Array, data: Uint8Array): void => {
-  checkUint8ArraySize(custom, data.length);
+export const checkBytesTypeEqual = (custom: BytesType, data: BytesType): void => {
+  checkSize(custom.length, data.length);
 
   for (let i = 0; i < custom.length; ++i)
     if (custom[i] !== data[i])
-      throw new Error(
-        `binary data mismatch: layout value: ${custom}, data value: ${data}`
-      );
-}
-
-export function getBytesItemSize(bytesItem: BytesLayoutItem): number | null {
-  if ("size" in bytesItem && bytesItem.size !== undefined)
-    return bytesItem.size;
-
-  if (isBytesType(bytesItem.custom))
-    return bytesItem.custom.length;
-
-  if (isBytesType(bytesItem?.custom?.from))
-    return bytesItem!.custom!.from.length;
-
-  return null;
+      throw new Error(`binary data mismatch: layout value: ${custom}, data value: ${data}`);
 }
 
 export function findIdLayoutPair(item: SwitchLayoutItem, data: any) {
   const id = data[item.idTag ?? "id"];
-  return (item.layouts as any[]).find(([idOrConversionId]) =>
+  return (item.layouts as readonly any[]).find(([idOrConversionId]) =>
     (Array.isArray(idOrConversionId) ? idOrConversionId[1] : idOrConversionId) == id
   )!;
 }

--- a/core/base/src/utils/mapping.ts
+++ b/core/base/src/utils/mapping.ts
@@ -234,7 +234,7 @@ type TransformMapping<M extends MappingEntries, S extends Shape | void = void> =
   //check that M has a valid structure for mapping entries
   CartesianRightRecursive<M> extends infer CRR extends RoArray2D
   ? IsRectangular<CRR> extends true
-  //ensure CRR is not empty  
+  //ensure CRR is not empty
   ? CRR extends readonly [RoArray, ...RoArray2D]
   ? S extends Shape
   ? SplitAndReorderKeyValueColumns<CRR, S> extends [

--- a/core/base/src/utils/metaprogramming.ts
+++ b/core/base/src/utils/metaprogramming.ts
@@ -50,6 +50,11 @@ export type ConcatStringLiterals<A extends RoArray<string>> =
 
 export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
 
+//if we were to just use the intersection type T & U, we'd lose strict property checks
+export type CombineObjects<T, U> = {
+  [K in keyof T | keyof U]: K extends keyof T ? T[K] : K extends keyof U ? U[K] : never;
+};
+
 // type MyUnion = 'foo' | 'bar' | 'baz';
 // type Test1 = IsUnionMember<'foo', MyUnion>; // true
 // type Test2 = IsUnionMember<'bar', MyUnion>; // true

--- a/core/definitions/src/layout-items/signature.ts
+++ b/core/definitions/src/layout-items/signature.ts
@@ -3,7 +3,6 @@ import {
   serializeLayout,
   deserializeLayout,
   CustomConversion,
-  FixedSizeBytesLayoutItem,
 } from "@wormhole-foundation/sdk-base";
 import { Signature } from "../signature";
 
@@ -24,4 +23,4 @@ export const signatureItem = {
     from: (val: Signature): Uint8Array =>
       serializeLayout(signatureLayout, { r: val.r, s: val.s, v: val.v }),
   } as const satisfies CustomConversion<Uint8Array, Signature>,
-} as const satisfies FixedSizeBytesLayoutItem;
+} as const satisfies Layout;

--- a/core/definitions/src/layout-items/signature.ts
+++ b/core/definitions/src/layout-items/signature.ts
@@ -1,7 +1,7 @@
 import {
   Layout,
-  serializeLayout,
-  deserializeLayout,
+  BytesLayoutItem,
+  LayoutToType,
   CustomConversion,
 } from "@wormhole-foundation/sdk-base";
 import { Signature } from "../signature";
@@ -15,12 +15,9 @@ const signatureLayout = [
 export const signatureItem = {
   binary: "bytes",
   size: 65,
+  layout: signatureLayout,
   custom: {
-    to: (val: Uint8Array): Signature => {
-      const sig = deserializeLayout(signatureLayout, val);
-      return new Signature(sig.r, sig.s, sig.v);
-    },
-    from: (val: Signature): Uint8Array =>
-      serializeLayout(signatureLayout, { r: val.r, s: val.s, v: val.v }),
-  } as const satisfies CustomConversion<Uint8Array, Signature>,
-} as const satisfies Layout;
+    to: (val: LayoutToType<typeof signatureLayout>) => new Signature(val.r, val.s, val.v),
+    from: (val: Signature) => ({ r: val.r, s: val.s, v: val.v }),
+  } as const satisfies CustomConversion<LayoutToType<typeof signatureLayout>, Signature>,
+} as const satisfies BytesLayoutItem;

--- a/core/definitions/src/layout-items/signature.ts
+++ b/core/definitions/src/layout-items/signature.ts
@@ -14,7 +14,6 @@ const signatureLayout = [
 
 export const signatureItem = {
   binary: "bytes",
-  size: 65,
   layout: signatureLayout,
   custom: {
     to: (val: LayoutToType<typeof signatureLayout>) => new Signature(val.r, val.s, val.v),

--- a/core/definitions/src/layout-items/universalAddress.ts
+++ b/core/definitions/src/layout-items/universalAddress.ts
@@ -1,6 +1,6 @@
 import {
+  LayoutItem,
   CustomConversion,
-  FixedSizeBytesLayoutItem,
 } from "@wormhole-foundation/sdk-base";
 import { UniversalAddress } from "../universalAddress";
 
@@ -11,4 +11,4 @@ export const universalAddressItem = {
     to: (val: Uint8Array): UniversalAddress => new UniversalAddress(val),
     from: (val: UniversalAddress): Uint8Array => val.toUint8Array(),
   } satisfies CustomConversion<Uint8Array, UniversalAddress>,
-} as const satisfies FixedSizeBytesLayoutItem;
+} as const satisfies LayoutItem;

--- a/core/definitions/src/payloads/automaticCircleBridge.ts
+++ b/core/definitions/src/payloads/automaticCircleBridge.ts
@@ -1,4 +1,4 @@
-import { Layout, LengthPrefixedBytesLayoutItem } from "@wormhole-foundation/sdk-base";
+import { Layout, FlexBytesLayoutItem } from "@wormhole-foundation/sdk-base";
 import {
   payloadIdItem,
   universalAddressItem,
@@ -9,12 +9,14 @@ import {
 import { RegisterPayloadTypes, NamedPayloads, registerPayloadTypes } from "../vaa";
 
 //from here: https://github.com/wormhole-foundation/wormhole-circle-integration/blob/105ad59bad687416527003e0241dee4020889341/evm/src/circle_integration/CircleIntegrationMessages.sol#L25
-const depositWithPayloadBase = [
+export const depositWithPayloadLayout = <P extends FlexBytesLayoutItem["custom"] = undefined>(
+  customPayload?: P,
+) => [
   payloadIdItem(1),
   {
     name: "token",
-    binary: "object",
-    layout: [
+    binary: "bytes",
+    custom: [
       { name: "address", ...universalAddressItem },
       { name: "amount", ...amountItem },
     ],
@@ -24,28 +26,8 @@ const depositWithPayloadBase = [
   { name: "nonce", ...circleNonceItem },
   { name: "caller", ...universalAddressItem },
   { name: "mintRecipient", ...universalAddressItem },
-] as const;
-
-//a future optimization would be to calculate the layout size from the layout itself
-//  thought that does require implementing arithmetic on number literals, which is its very
-//  own can of worms
-export const depositWithSizedLayoutPayload = <S extends number, L extends Layout>(
-  byteSize: S,
-  layout: L,
-) =>
-  [
-    ...depositWithPayloadBase,
-    { name: "payloadSize", binary: "uint", size: 2, custom: byteSize, omit: true },
-    { name: "payload", binary: "object", layout },
-  ] as const;
-
-export const depositWithBytesPayload = <C extends Pick<LengthPrefixedBytesLayoutItem, "custom">>(
-  customPayload: C,
-) =>
-  [
-    ...depositWithPayloadBase,
-    { name: "payload", binary: "bytes", lengthSize: 2, ...customPayload },
-  ] as const;
+  { name: "payload", binary: "bytes", lengthSize: 2 , custom: customPayload as P },
+] as const satisfies Layout;
 
 //from here:
 //  https://github.com/wormhole-foundation/example-circle-relayer/blob/189becd8d3935decb17383bd2e61b4909cbddc89/evm/src/circle-relayer/CircleRelayerMessages.sol#L16
@@ -57,8 +39,8 @@ export const connectPayload = [
 ] as const;
 
 export const namedPayloads = [
-  ["DepositWithPayload", depositWithBytesPayload({})],
-  ["TransferWithRelay", depositWithSizedLayoutPayload(1 + 3 * 32, connectPayload)],
+  ["DepositWithPayload", depositWithPayloadLayout()],
+  ["TransferWithRelay", depositWithPayloadLayout(connectPayload)],
 ] as const satisfies NamedPayloads;
 
 // factory registration:

--- a/core/definitions/src/payloads/automaticCircleBridge.ts
+++ b/core/definitions/src/payloads/automaticCircleBridge.ts
@@ -1,4 +1,4 @@
-import { Layout, FlexBytesLayoutItem } from "@wormhole-foundation/sdk-base";
+import { Layout, CustomizableBytes, customizableBytes } from "@wormhole-foundation/sdk-base";
 import {
   payloadIdItem,
   universalAddressItem,
@@ -9,14 +9,14 @@ import {
 import { RegisterPayloadTypes, NamedPayloads, registerPayloadTypes } from "../vaa";
 
 //from here: https://github.com/wormhole-foundation/wormhole-circle-integration/blob/105ad59bad687416527003e0241dee4020889341/evm/src/circle_integration/CircleIntegrationMessages.sol#L25
-export const depositWithPayloadLayout = <P extends FlexBytesLayoutItem["custom"] = undefined>(
+export const depositWithPayloadLayout = <const P extends CustomizableBytes = undefined>(
   customPayload?: P,
 ) => [
   payloadIdItem(1),
   {
     name: "token",
     binary: "bytes",
-    custom: [
+    layout: [
       { name: "address", ...universalAddressItem },
       { name: "amount", ...amountItem },
     ],
@@ -26,7 +26,7 @@ export const depositWithPayloadLayout = <P extends FlexBytesLayoutItem["custom"]
   { name: "nonce", ...circleNonceItem },
   { name: "caller", ...universalAddressItem },
   { name: "mintRecipient", ...universalAddressItem },
-  { name: "payload", binary: "bytes", lengthSize: 2 , custom: customPayload as P },
+  customizableBytes({ name: "payload", lengthSize: 2}, customPayload),
 ] as const satisfies Layout;
 
 //from here:

--- a/core/definitions/src/payloads/automaticTokenBridge.ts
+++ b/core/definitions/src/payloads/automaticTokenBridge.ts
@@ -12,7 +12,7 @@ export const connectPayload = [
 ] as const;
 
 export const namedPayloads = [
-  ["TransferWithRelay", transferWithPayloadLayout({ binary: "object", layout: connectPayload })],
+  ["TransferWithRelay", transferWithPayloadLayout(connectPayload)],
 ] as const satisfies NamedPayloads;
 
 // factory registration:

--- a/core/definitions/src/payloads/bam.ts
+++ b/core/definitions/src/payloads/bam.ts
@@ -1,7 +1,8 @@
 import {
   Layout,
   UintLayoutItem,
-  LengthPrefixedBytesLayoutItem,
+  CustomizableBytes,
+  customizableBytes,
 } from "@wormhole-foundation/sdk-base";
 import { chainItem, amountItem } from "../layout-items";
 import { RegisterPayloadTypes, NamedPayloads, registerPayloadTypes } from "../vaa";
@@ -9,13 +10,13 @@ import { RegisterPayloadTypes, NamedPayloads, registerPayloadTypes } from "../va
 const bamAddressItem = {
   binary: "bytes",
   lengthSize: 2,
-} as const satisfies LengthPrefixedBytesLayoutItem;
+} as const;
 
 const customOrEmpty = (custom: any) => (custom ? { custom } : {});
 
 export const messageLayout = <
   T extends number,
-  C extends Pick<LengthPrefixedBytesLayoutItem, "custom">,
+  const C extends CustomizableBytes = undefined,
 >(
   type: T,
   customContents?: C,
@@ -28,13 +29,13 @@ export const messageLayout = <
     { name: "targetChain", ...chainItem() },
     { name: "targetAddress", ...bamAddressItem },
     { name: "senderAddress", ...bamAddressItem },
-    { name: "contents", binary: "bytes", lengthSize: 2, ...customOrEmpty(customContents) },
+    customizableBytes({ name: "contents", lengthSize: 2 }, customContents),
   ] as const satisfies Layout;
 
 export const tokenMessageLayout = <
-  C extends Pick<LengthPrefixedBytesLayoutItem, "custom">,
   B extends Pick<UintLayoutItem, "custom">,
   A extends Pick<UintLayoutItem, "custom">,
+  const C extends CustomizableBytes = undefined,
 >(custom?: {
   contents?: C;
   bridge?: B;
@@ -48,15 +49,15 @@ export const tokenMessageLayout = <
   ] as const satisfies Layout;
 
 export const extendedMessageLayout = <
-  C extends Pick<LengthPrefixedBytesLayoutItem, "custom">,
-  R extends Pick<LengthPrefixedBytesLayoutItem, "custom">,
+  const C extends CustomizableBytes = undefined,
+  const R extends CustomizableBytes = undefined,
 >(custom?: {
   contents?: C;
   relaySignal?: R;
 }) =>
   [
     ...messageLayout(2, custom?.contents),
-    { name: "relaySignal", binary: "bytes", lengthSize: 2, ...customOrEmpty(custom?.relaySignal) },
+    customizableBytes({ name: "relaySignal", lengthSize: 2}, custom?.relaySignal),
   ] as const satisfies Layout;
 
 export const namedPayloads = [

--- a/core/definitions/src/payloads/circleBridge.ts
+++ b/core/definitions/src/payloads/circleBridge.ts
@@ -33,7 +33,7 @@ export const circleMessageLayout = [
   { name: "sender", ...universalAddressItem },
   { name: "recipient", ...universalAddressItem },
   { name: "destinationCaller", ...universalAddressItem },
-  { name: "payload", binary: "object", layout: circleBurnMessageLayout },
+  { name: "payload", binary: "bytes", custom: circleBurnMessageLayout },
 ] as const satisfies Layout;
 
 export const namedPayloads = [["Message", circleMessageLayout]] as const satisfies NamedPayloads;

--- a/core/definitions/src/payloads/circleBridge.ts
+++ b/core/definitions/src/payloads/circleBridge.ts
@@ -33,7 +33,7 @@ export const circleMessageLayout = [
   { name: "sender", ...universalAddressItem },
   { name: "recipient", ...universalAddressItem },
   { name: "destinationCaller", ...universalAddressItem },
-  { name: "payload", binary: "bytes", custom: circleBurnMessageLayout },
+  { name: "payload", binary: "bytes", layout: circleBurnMessageLayout },
 ] as const satisfies Layout;
 
 export const namedPayloads = [["Message", circleMessageLayout]] as const satisfies NamedPayloads;

--- a/core/definitions/src/payloads/ntt.ts
+++ b/core/definitions/src/payloads/ntt.ts
@@ -2,7 +2,8 @@ import {
   Layout,
   LayoutToType,
   CombineObjects,
-  FlexBytesLayoutItem,
+  CustomizableBytes,
+  customizableBytes,
 } from "@wormhole-foundation/sdk-base";
 
 import { universalAddressItem, chainItem, sequenceItem } from "../layout-items";
@@ -22,7 +23,7 @@ const prefixLayout = <const P extends Prefix>(prefix: P) => [
 
 export const nativeTokenTransferLayout = [
   ...prefixLayout([0x99, 0x4E, 0x54, 0x54]),
-  {name: "normalizedAmount", binary: "bytes", custom: normalizedAmountLayout},
+  {name: "normalizedAmount", binary: "bytes", layout: normalizedAmountLayout},
   {name: "sourceToken", ...universalAddressItem},
   {name: "recipientAddress", ...universalAddressItem},
   {name: "recipientChain", ...chainItem()},
@@ -37,10 +38,10 @@ export const endpointMessageBaseLayout = <const PF extends Prefix>(prefix: PF) =
 
 export const endpointMessageLayout = <
   const PF extends Prefix,
-  const P extends FlexBytesLayoutItem["custom"] = undefined,
+  const P extends CustomizableBytes = undefined,
 >(prefix: PF, customPayload?: P) => [
   ...endpointMessageBaseLayout(prefix),
-  {name: "managerPayload", binary: "bytes", lengthSize: 2, custom: customPayload as P},
+  customizableBytes({name: "managerPayload", lengthSize: 2}, customPayload),
 ] as const satisfies Layout;
 
 type EndpointMessageBase = LayoutToType<ReturnType<typeof endpointMessageBaseLayout<Prefix>>>;
@@ -55,16 +56,16 @@ export const managerMessageLayoutBase = [
 type ManagerMessageBase = LayoutToType<typeof managerMessageLayoutBase>;
 
 export const managerMessageLayout = <
-  const P extends FlexBytesLayoutItem["custom"] = undefined
+  const P extends CustomizableBytes = undefined
 >(customPayload?: P) => [
   ...managerMessageLayoutBase,
-  {name: "payload", binary: "bytes", lengthSize: 2, custom: customPayload as P},
+  customizableBytes({name: "payload", lengthSize: 2}, customPayload),
 ] as const satisfies Layout;
 
 export type ManagerMessage<P> = CombineObjects<ManagerMessageBase, {payload: P}>;
 
 export const wormholeEndpointMessage = <
-  const P extends FlexBytesLayoutItem["custom"] = undefined
+  const P extends CustomizableBytes = undefined
 >(customPayload?: P) =>
   endpointMessageLayout([0x99, 0x45, 0xFF, 0x10], customPayload);
 

--- a/core/definitions/src/payloads/ntt.ts
+++ b/core/definitions/src/payloads/ntt.ts
@@ -1,0 +1,71 @@
+import {
+  Layout,
+  LayoutToType,
+  CombineObjects,
+  FlexBytesLayoutItem,
+} from "@wormhole-foundation/sdk-base";
+
+import { universalAddressItem, chainItem, sequenceItem } from "../layout-items";
+
+export const normalizedAmountLayout = [
+  {name: "decimals", binary: "uint", size: 1},
+  {name: "amount", binary: "uint", size: 8},
+] as const satisfies Layout;
+
+export type NormalizedAmount = LayoutToType<typeof normalizedAmountLayout>;
+
+export type Prefix = readonly [number, number, number, number];
+
+const prefixLayout = <const P extends Prefix>(prefix: P) => [
+  {name: "prefix", binary: "bytes", custom: Uint8Array.from(prefix), omit: true},
+] as const satisfies Layout;
+
+export const nativeTokenTransferLayout = [
+  ...prefixLayout([0x99, 0x4E, 0x54, 0x54]),
+  {name: "normalizedAmount", binary: "bytes", custom: normalizedAmountLayout},
+  {name: "sourceToken", ...universalAddressItem},
+  {name: "recipientAddress", ...universalAddressItem},
+  {name: "recipientChain", ...chainItem()},
+] as const satisfies Layout;
+
+export type NativeTokenTransfer = LayoutToType<typeof nativeTokenTransferLayout>;
+
+export const endpointMessageBaseLayout = <const PF extends Prefix>(prefix: PF) => [
+  ...prefixLayout(prefix),
+  {name: "sourceManager", ...universalAddressItem},
+] as const satisfies Layout;
+
+export const endpointMessageLayout = <
+  const PF extends Prefix,
+  const P extends FlexBytesLayoutItem["custom"] = undefined,
+>(prefix: PF, customPayload?: P) => [
+  ...endpointMessageBaseLayout(prefix),
+  {name: "managerPayload", binary: "bytes", lengthSize: 2, custom: customPayload as P},
+] as const satisfies Layout;
+
+type EndpointMessageBase = LayoutToType<ReturnType<typeof endpointMessageBaseLayout<Prefix>>>;
+
+export type EndpointMessage<P> = CombineObjects<EndpointMessageBase, {managerPayload: P}>;
+
+export const managerMessageLayoutBase = [
+  {name: "sequence", ...sequenceItem},
+  {name: "sender", ...universalAddressItem},
+] as const satisfies Layout;
+
+type ManagerMessageBase = LayoutToType<typeof managerMessageLayoutBase>;
+
+export const managerMessageLayout = <
+  const P extends FlexBytesLayoutItem["custom"] = undefined
+>(customPayload?: P) => [
+  ...managerMessageLayoutBase,
+  {name: "payload", binary: "bytes", lengthSize: 2, custom: customPayload as P},
+] as const satisfies Layout;
+
+export type ManagerMessage<P> = CombineObjects<ManagerMessageBase, {payload: P}>;
+
+export const wormholeEndpointMessage = <
+  const P extends FlexBytesLayoutItem["custom"] = undefined
+>(customPayload?: P) =>
+  endpointMessageLayout([0x99, 0x45, 0xFF, 0x10], customPayload);
+
+export type WormholeEndpointMessage<P> = EndpointMessage<P>;

--- a/core/definitions/src/payloads/portico.ts
+++ b/core/definitions/src/payloads/portico.ts
@@ -15,7 +15,7 @@ export const porticoFlagSetLayout = [
 ] as const satisfies Layout;
 
 export const porticoTransferLayout = [
-  { name: "flagSet", binary: "bytes", custom: porticoFlagSetLayout },
+  { name: "flagSet", binary: "bytes", layout: porticoFlagSetLayout },
   { name: "startTokenAddress", ...universalAddressItem },
   { name: "cannonAssetAmount", ...amountItem },
   { name: "finalTokenAddress", ...universalAddressItem },
@@ -28,7 +28,7 @@ export const porticoTransferLayout = [
 ] as const satisfies Layout;
 
 export const porticoPayloadLayout = [
-  { name: "flagSet", binary: "bytes", custom: porticoFlagSetLayout },
+  { name: "flagSet", binary: "bytes", layout: porticoFlagSetLayout },
   { name: "finalTokenAddress", ...universalAddressItem },
   { name: "recipientAddress", ...universalAddressItem },
   { name: "cannonAssetAmount", ...amountItem },

--- a/core/definitions/src/payloads/portico.ts
+++ b/core/definitions/src/payloads/portico.ts
@@ -2,17 +2,20 @@ import { Layout, bitsetItem } from "@wormhole-foundation/sdk-base";
 import { amountItem, universalAddressItem } from "../layout-items";
 import { NamedPayloads, RegisterPayloadTypes, registerPayloadTypes } from "../vaa";
 
+//weirdly, if defined in place, the type is not inferred properly
+const flagsItem = bitsetItem(["shouldWrapNative", "shouldUnwrapNative"]);
+
 export const porticoFlagSetLayout = [
   { name: "recipientChain", binary: "uint", endianness: "little", size: 2 },
   { name: "bridgeNonce", binary: "uint", endianness: "little", size: 4 },
   { name: "feeTierStart", binary: "uint", endianness: "little", size: 3 },
   { name: "feeTierFinish", binary: "uint", endianness: "little", size: 3 },
   { name: "padding", binary: "bytes", size: 19 },
-  { name: "flags", ...bitsetItem(["shouldWrapNative", "shouldUnwrapNative"]) },
+  { name: "flags", ...flagsItem },
 ] as const satisfies Layout;
 
 export const porticoTransferLayout = [
-  { name: "flagSet", binary: "object", layout: porticoFlagSetLayout },
+  { name: "flagSet", binary: "bytes", custom: porticoFlagSetLayout },
   { name: "startTokenAddress", ...universalAddressItem },
   { name: "cannonAssetAmount", ...amountItem },
   { name: "finalTokenAddress", ...universalAddressItem },
@@ -25,7 +28,7 @@ export const porticoTransferLayout = [
 ] as const satisfies Layout;
 
 export const porticoPayloadLayout = [
-  { name: "flagSet", binary: "object", layout: porticoFlagSetLayout },
+  { name: "flagSet", binary: "bytes", custom: porticoFlagSetLayout },
   { name: "finalTokenAddress", ...universalAddressItem },
   { name: "recipientAddress", ...universalAddressItem },
   { name: "cannonAssetAmount", ...amountItem },

--- a/core/definitions/src/payloads/relayer.ts
+++ b/core/definitions/src/payloads/relayer.ts
@@ -1,4 +1,4 @@
-import { LayoutItem, FlexBytesLayoutItem } from "@wormhole-foundation/sdk-base";
+import { LayoutItem, CustomizableBytes, customizableBytes } from "@wormhole-foundation/sdk-base";
 import {
   amountItem,
   chainItem,
@@ -12,7 +12,7 @@ import { NamedPayloads, RegisterPayloadTypes, registerPayloadTypes } from "../va
 
 const encodedExecutionInfoItem = {
   binary: "bytes",
-  custom: [
+  layout: [
     { name: "size", binary: "uint", size: 4, custom: 3 * 32, omit: true },
     { name: "waste", binary: "uint", size: 31, custom: 0n, omit: true },
     { name: "version", binary: "uint", size: 1, custom: 0, omit: true },
@@ -23,7 +23,7 @@ const encodedExecutionInfoItem = {
 
 const addressChainItem = {
   binary: "bytes",
-  custom: [
+  layout: [
     { name: "chain", ...chainItem() },
     { name: "address", ...universalAddressItem },
   ],
@@ -52,11 +52,11 @@ const messageKeySwitchLayout = {
 } as const satisfies LayoutItem;
 
 export const deviveryInstructionLayout = <
-  const P extends FlexBytesLayoutItem["custom"] = undefined
+  const P extends CustomizableBytes = undefined
 >(customPayload?: P) => [
   payloadIdItem(1),
   { name: "target", ...addressChainItem },
-  { name: "payload", binary: "bytes", lengthSize: 4, custom: customPayload as P },
+  customizableBytes({ name: "payload", lengthSize: 4}, customPayload),
   { name: "requestedReceiverValue", ...amountItem },
   { name: "extraReceiverValue", ...amountItem },
   { name: "executionInfo", ...encodedExecutionInfoItem },
@@ -71,7 +71,7 @@ const namedPayloads = [
   [ "DeliveryInstruction", deviveryInstructionLayout() ],
   [ "RedeliveryInstruction", [
       payloadIdItem(2),
-      { name: "deliveryVaaKey", binary: "bytes", custom: vaaKeyLayout },
+      { name: "deliveryVaaKey", binary: "bytes", layout: vaaKeyLayout },
       { name: "targetChain", ...chainItem() },
       { name: "newRequestedReceiverValue", ...amountItem },
       { name: "newEncodedExecutionInfo", ...encodedExecutionInfoItem },

--- a/core/definitions/src/payloads/tokenBridge.ts
+++ b/core/definitions/src/payloads/tokenBridge.ts
@@ -2,8 +2,9 @@ import {
   Layout,
   LayoutItem,
   CustomConversion,
+  CustomizableBytes,
+  customizableBytes,
   range,
-  FlexBytesLayoutItem,
 } from "@wormhole-foundation/sdk-base";
 import { payloadIdItem, chainItem, universalAddressItem, amountItem } from "../layout-items";
 import { NamedPayloads, RegisterPayloadTypes, registerPayloadTypes } from "../vaa";
@@ -21,13 +22,13 @@ const fixedLengthStringItem = {
 } as const satisfies LayoutItem;
 
 const transferCommonLayout = [
-  { name: "token", binary: "bytes", custom: [
+  { name: "token", binary: "bytes", layout: [
       { name: "amount", ...amountItem },
       { name: "address", ...universalAddressItem },
       { name: "chain", ...chainItem() },
     ],
   },
-  { name: "to", binary: "bytes", custom: [
+  { name: "to", binary: "bytes", layout: [
       { name: "address", ...universalAddressItem },
       { name: "chain", ...chainItem() },
     ],
@@ -35,12 +36,12 @@ const transferCommonLayout = [
 ] as const satisfies Layout;
 
 export const transferWithPayloadLayout = <
-  const P extends FlexBytesLayoutItem["custom"] = undefined
+  const P extends CustomizableBytes = undefined
 >(customPayload?: P) => [
   payloadIdItem(3),
   ...transferCommonLayout,
   { name: "from", ...universalAddressItem },
-  { name: "payload", binary: "bytes", custom: customPayload as P },
+  customizableBytes({ name: "payload"}, customPayload),
 ] as const;
 
 export const namedPayloads = [
@@ -51,7 +52,7 @@ export const namedPayloads = [
       {
         name: "token",
         binary: "bytes",
-        custom: [
+        layout: [
           { name: "address", ...universalAddressItem },
           { name: "chain", ...chainItem() },
         ],

--- a/core/definitions/src/signature.ts
+++ b/core/definitions/src/signature.ts
@@ -1,3 +1,7 @@
+import {
+  serializeLayout,
+  deserializeLayout,
+} from "@wormhole-foundation/sdk-base";
 import { signatureItem } from "./layout-items";
 
 /** Signature represents the secp256k1 signature of a Guardian */
@@ -9,10 +13,10 @@ export class Signature {
   ) {}
 
   encode(): Uint8Array {
-    return signatureItem.custom.from(this);
+    return serializeLayout(signatureItem, this);
   }
 
   static decode(data: Uint8Array): Signature {
-    return signatureItem.custom.to(data);
+    return deserializeLayout(signatureItem, data);
   }
 }

--- a/core/definitions/src/vaa/create.ts
+++ b/core/definitions/src/vaa/create.ts
@@ -16,18 +16,18 @@ import { PayloadLiteralToPayloadItemLayout, payloadLiteralToPayloadItemLayout } 
 
 type BodyLayout<PL extends PayloadLiteral> = [
   ...typeof envelopeLayout,
-  ...PayloadLiteralToPayloadItemLayout<PL>,
+  PayloadLiteralToPayloadItemLayout<PL>,
 ];
 
 function bodyLayout<PL extends PayloadLiteral>(payloadLiteral: PL) {
   return [
     ...envelopeLayout,
-    ...payloadLiteralToPayloadItemLayout(payloadLiteral),
+    payloadLiteralToPayloadItemLayout(payloadLiteral),
   ] as BodyLayout<PL>;
 }
 
 type DynamicProperties<PL extends PayloadLiteral> = LayoutToType<
-  DynamicItemsOfLayout<[...typeof baseLayout, ...PayloadLiteralToPayloadItemLayout<PL>]>
+  DynamicItemsOfLayout<[...typeof baseLayout, PayloadLiteralToPayloadItemLayout<PL>]>
 >;
 
 export function createVAA<PL extends PayloadLiteral>(

--- a/core/definitions/src/vaa/functions.ts
+++ b/core/definitions/src/vaa/functions.ts
@@ -37,9 +37,10 @@ export function getPayloadLayout<LL extends LayoutLiteral>(layoutLiteral: LL) {
 }
 
 //annoyingly we can't implicitly declare this using the return type of payloadLiteralToPayloadItem
-export type PayloadLiteralToPayloadItemLayout<PL extends PayloadLiteral> = PL extends infer V
+export type PayloadLiteralToPayloadItemLayout<PL extends PayloadLiteral> =
+  PL extends infer V
   ? V extends LayoutLiteral
-    ? { name: "payload"; binary: "bytes"; custom: LayoutOf<V> }
+    ? { name: "payload"; binary: "bytes"; layout: LayoutOf<V> }
     : V extends "Uint8Array"
     ? { name: "payload"; binary: "bytes" }
     : never
@@ -49,7 +50,7 @@ export function payloadLiteralToPayloadItemLayout<PL extends PayloadLiteral>(pay
   return {
     name: "payload",
     binary: "bytes",
-    ...(payloadLiteral === "Uint8Array" ? {} : {custom: getPayloadLayout(payloadLiteral)})
+    ...(payloadLiteral === "Uint8Array" ? {} : {layout: getPayloadLayout(payloadLiteral)})
   } as PayloadLiteralToPayloadItemLayout<PL>;
 }
 

--- a/platforms/cosmwasm/src/address.ts
+++ b/platforms/cosmwasm/src/address.ts
@@ -55,14 +55,14 @@ There are at least 5 types of addresses in Cosmos:
     address = [0x...] // 32 bytes
     domain = undefined
     denom = undefined
-    denomType = "IBC" 
+    denomType = "IBC"
 
   Factory Address
     ex: "factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/avax"
 
     address = [0x...] 20 bytes
-    domain = "inj" 
-    denom =  "avax" 
+    domain = "inj"
+    denom =  "avax"
     denomType = "factory"
 
   Transfer Denom


### PR DESCRIPTION
killed ObjectLayout item and instead moved its abilities to custom field of BytesLayout item

BytesLayoutItems can now enforce a size or a lengthSize while also natively supporting custom layouts (instead of having to wrap the layout in a CustomConversion and hence losing discrimination power, etc.)

implemented new custom payload mechanism for all payloads that have user definable payloads

also implemented NTT payloads