### PR TITLE
import platforms dynamically

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -34,8 +34,8 @@
   "scripts": {
     "build:cjs":"tsc -p ./tsconfig.cjs.json",
     "build:esm": "tsc -p ./tsconfig.esm.json",
-    "build": "npm run build:cjs && npm run build:esm",
-    "rebuild": "npm run clean && npm run build:cjs && npm run build:esm",
+    "build": "npm run build:esm",
+    "rebuild": "npm run clean && npm run build:esm",
     "clean": "rm -rf ./dist && rm -f ./*.tsbuildinfo",
     "lint": "npm run prettier && eslint --fix",
     "prettier": "prettier --write ./src",

--- a/sdk/src/algorand.ts
+++ b/sdk/src/algorand.ts
@@ -1,4 +1,4 @@
-import * as _algorand from "@wormhole-foundation/sdk-algorand";
+const _algorand = await import("@wormhole-foundation/sdk-algorand");
 
 /** Platform and protocol definitions for Algorand */
 export const algorand = {

--- a/sdk/src/aptos.ts
+++ b/sdk/src/aptos.ts
@@ -1,4 +1,4 @@
-import * as _aptos from "@wormhole-foundation/sdk-aptos";
+const _aptos = await import("@wormhole-foundation/sdk-aptos");
 
 /** Platform and protocol definitions for Aptos */
 export const aptos = {

--- a/sdk/src/cosmwasm.ts
+++ b/sdk/src/cosmwasm.ts
@@ -1,4 +1,4 @@
-import * as _cosmwasm from "@wormhole-foundation/sdk-cosmwasm";
+const _cosmwasm = await import("@wormhole-foundation/sdk-cosmwasm");
 
 /** Platform and protocol definitions for Cosmwasm */
 export const cosmwasm = {

--- a/sdk/src/evm.ts
+++ b/sdk/src/evm.ts
@@ -1,4 +1,4 @@
-import * as _evm from "@wormhole-foundation/sdk-evm";
+const _evm = await import("@wormhole-foundation/sdk-evm");
 /** Platform and protocol definitions for Evm */
 export const evm = {
   ...{

--- a/sdk/src/solana.ts
+++ b/sdk/src/solana.ts
@@ -1,4 +1,4 @@
-import * as _solana from "@wormhole-foundation/sdk-solana";
+const _solana = await import("@wormhole-foundation/sdk-solana");
 /** Platform and protocol definitons for Solana */
 export const solana = {
   ...{

--- a/sdk/src/sui.ts
+++ b/sdk/src/sui.ts
@@ -1,4 +1,4 @@
-import * as _sui from "@wormhole-foundation/sdk-sui";
+const _sui = await import("@wormhole-foundation/sdk-sui");
 
 /** Platform and protocol definitions for Sui */
 export const sui = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "lib": ["es2022"],
-    "target": "es2022",
-    "module": "es2022",
+    "target": "ES2022",
+    "module": "ES2022",
     "types": ["mocha", "chai", "node", "jest"],
     "esModuleInterop": true,
     "strict": true,
@@ -45,6 +45,6 @@
     "noImplicitUseStrict": false,
     "suppressExcessPropertyErrors": false,
     "suppressImplicitAnyIndexErrors": false,
-    "noStrictGenericChecks": false,
+    "noStrictGenericChecks": false
   }
 }


### PR DESCRIPTION
This allows the individual Platform packages to be chunked in downstream/client bundlers (e.g. web app can chunk and package separately)