### PR TITLE
fix type inference for wormhole loader

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -37,7 +37,7 @@ export interface PlatformDefinition<
 
 export async function wormhole<N extends Network>(
   network: N,
-  platformLoaders: (() => Promise<PlatformDefinition<N>>)[],
+  platformLoaders: (() => Promise<PlatformDefinition>)[],
   config?: ConfigOverrides,
 ): Promise<Wormhole<N>> {
   // make sure all protocols are loaded
@@ -53,7 +53,7 @@ export async function wormhole<N extends Network>(
       ),
     );
 
-    return new Wormhole(
+    return new Wormhole<N>(
       network,
       platforms.map((p) => p.Platform),
       config,


### PR DESCRIPTION
Fixes type inference for the `Wormhole` obj generic parameter.

Without this, `wormhole("Testnet", ...)` is inferred to `Wormhole<"Mainnet"|"Testnet"|"Devnet">`

with this, its properly set to `Wormhole<"Testnet">`